### PR TITLE
Fix breaking typo

### DIFF
--- a/preprocessing/acoustic_binarizer.py
+++ b/preprocessing/acoustic_binarizer.py
@@ -218,7 +218,7 @@ class AcousticBinarizer(BaseBinarizer):
 
         if self.need_falsetto:
             # get ground truth falsetto
-            falsetto = get_falestto_base_harmonic(
+            falsetto = get_falsetto_base_harmonic(
                 dec_waveform, None, None, length=length
             )
 

--- a/utils/binarizer_utils.py
+++ b/utils/binarizer_utils.py
@@ -215,7 +215,7 @@ def get_falsetto_base_harmonic(
         *, hop_size=None, fft_size=None, win_size=None
 ):
     """
-    Definition of falestto: Attenuation ratio from the second harmonic to the fourth harmonic (H2 / (H2 + H4)).
+    Definition of falsetto: Attenuation ratio from the second harmonic to the fourth harmonic (H2 / (H2 + H4)).
     Refer to : ACOUSTIC MEASURES OF FALSETTO VOICE (DOI:10.1121/1.4877544)
     :param waveform: All other analysis parameters will not take effect if a DeconstructedWaveform is given
     :param samplerate: sampling rate
@@ -224,7 +224,7 @@ def get_falsetto_base_harmonic(
     :param hop_size: Frame width, in number of samples
     :param fft_size: Number of fft bins
     :param win_size: Window size, in number of samples
-    :return: falestto
+    :return: falsetto
     """
     if not isinstance(waveform, DecomposedWaveform):
         waveform = DecomposedWaveform(
@@ -243,9 +243,9 @@ def get_falsetto_base_harmonic(
         hop_size=waveform.hop_size, win_size=waveform.win_size,
         domain='amplitude'
     )
-    falestto = energy_h2 / (energy_h2 + energy_h4 + 1e-5)
-    falestto = np.clip(falestto, a_min=0, a_max=1)
-    return falestto
+    falsetto = energy_h2 / (energy_h2 + energy_h4 + 1e-5)
+    falsetto = np.clip(falsetto, a_min=0, a_max=1)
+    return falsetto
 
 
 class SinusoidalSmoothingConv1d(torch.nn.Conv1d):


### PR DESCRIPTION
The error in the acoustic binarizer prevented binarization. The ones in binarizer_utils might have canceled each other out, but it's best to fix them for clarity.