### PR TITLE
feat: integrate upstream dual-timestep reflow

### DIFF
--- a/configs/acoustic.yaml
+++ b/configs/acoustic.yaml
@@ -61,6 +61,7 @@ use_key_shift_embed: false
 use_speed_embed: false
 
 diffusion_type: reflow
+use_dual_timestep: true
 time_scale_factor: 1000
 timesteps: 1000
 max_beta: 0.02

--- a/configs/templates/config_acoustic.yaml
+++ b/configs/templates/config_acoustic.yaml
@@ -72,6 +72,7 @@ augmentation_args:
 
 # diffusion and shallow diffusion
 diffusion_type: reflow
+use_dual_timestep: true
 enc_ffn_kernel_size: 3
 use_rope: true
 rope_interleaved: false

--- a/configs/templates/config_variance.yaml
+++ b/configs/templates/config_variance.yaml
@@ -90,6 +90,7 @@ glide_types: [up, down]
 glide_embed_scale: 11.313708498984760  # sqrt(128)
 
 diffusion_type: reflow
+use_dual_timestep: true
 
 pitch_prediction_args:
   pitd_norm_min: -8.0

--- a/configs/variance.yaml
+++ b/configs/variance.yaml
@@ -106,6 +106,7 @@ lambda_pitch_loss: 1.0
 lambda_var_loss: 1.0
 
 diffusion_type: reflow  # ddpm
+use_dual_timestep: true
 time_scale_factor: 1000
 schedule_type: 'linear'
 K_step: 1000

--- a/modules/backbones/lynxnet.py
+++ b/modules/backbones/lynxnet.py
@@ -6,7 +6,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from modules.commons.common_layers import SinusoidalPosEmb, SwiGLU, Transpose, AdamWConv1d
+from modules.commons.common_layers import (
+    AdamWConv1d,
+    SinusoidalPosEmb,
+    SwiGLU,
+    Transpose,
+    interpolate_dual_timestep_embedding,
+)
 from modules.commons.common_layers import KaimingNormalConv1d as Conv1d
 from utils.hparams import hparams
 
@@ -127,14 +133,12 @@ class LYNXNet(nn.Module):
         if not self.strong_cond:
             x = F.gelu(x)
 
-        if mask is not None:
-            step = torch.cat((diffusion_step, diffusion_step_2), dim=0)
-            step = self.diffusion_embedding(step)
-            step, step_2 = torch.split(step, x.shape[0], dim=0) #[B, 1, C]
-            mask = mask.to(x).unsqueeze(-1) # [B, T, 1]
-            step = step + (step_2 - step) * mask
-        else:
-            step = self.diffusion_embedding(diffusion_step)
+        step = interpolate_dual_timestep_embedding(
+            self.diffusion_embedding,
+            diffusion_step,
+            diffusion_step_2,
+            mask,
+        )
 
         for layer in self.residual_layers:
             x = layer(x, cond, step.transpose(1, 2), front_cond_inject=self.strong_cond)

--- a/modules/backbones/lynxnet.py
+++ b/modules/backbones/lynxnet.py
@@ -2,6 +2,7 @@
 # https://github.com/CNChTu/Diffusion-SVC/blob/v2.0_dev/diffusion/naive_v2/model_conformer_naive.py
 # https://github.com/CNChTu/Diffusion-SVC/blob/v2.0_dev/diffusion/naive_v2/naive_v2_diff.py
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -109,7 +110,7 @@ class LYNXNet(nn.Module):
         self.strong_cond = strong_cond
         nn.init.zeros_(self.output_projection.weight)
 
-    def forward(self, spec, diffusion_step, cond):
+    def forward(self, spec, diffusion_step, cond, diffusion_step_2=None, mask=None):
         """
         :param spec: [B, F, M, T]
         :param diffusion_step: [B, 1]
@@ -126,10 +127,17 @@ class LYNXNet(nn.Module):
         if not self.strong_cond:
             x = F.gelu(x)
 
-        diffusion_step = self.diffusion_embedding(diffusion_step).unsqueeze(-1)
+        if mask is not None:
+            step = torch.cat((diffusion_step, diffusion_step_2), dim=0)
+            step = self.diffusion_embedding(step)
+            step, step_2 = torch.split(step, x.shape[0], dim=0) #[B, 1, C]
+            mask = mask.to(x).unsqueeze(-1) # [B, T, 1]
+            step = step + (step_2 - step) * mask
+        else:
+            step = self.diffusion_embedding(diffusion_step)
 
         for layer in self.residual_layers:
-            x = layer(x, cond, diffusion_step, front_cond_inject=self.strong_cond)
+            x = layer(x, cond, step.transpose(1, 2), front_cond_inject=self.strong_cond)
 
         # post-norm
         x = self.norm(x.transpose(1, 2)).transpose(1, 2)

--- a/modules/backbones/lynxnet2.py
+++ b/modules/backbones/lynxnet2.py
@@ -77,7 +77,7 @@ class LYNXNet2(nn.Module):
         nn.init.kaiming_normal_(self.conditioner_projection.weight)
         nn.init.zeros_(self.output_projection.weight)
 
-    def forward(self, spec, diffusion_step, cond):
+    def forward(self, spec, diffusion_step, cond, diffusion_step_2=None, mask=None):
         """
         :param spec: [B, F, M, T]
         :param diffusion_step: [B, 1]
@@ -95,7 +95,15 @@ class LYNXNet2(nn.Module):
             x = x + self.conditioner_projection(cond).transpose(1, 2)
         else:
             x = x + self.conditioner_projection(cond.transpose(1, 2))
-        x = x + self.diffusion_embedding(diffusion_step).unsqueeze(1)
+        
+        if mask is not None:
+            step = torch.cat((diffusion_step, diffusion_step_2), dim=0)
+            step = self.diffusion_embedding(step)
+            step, step_2 = torch.split(step, x.shape[0], dim=0) #[B, 1, C]
+            mask = mask.to(x).unsqueeze(-1) # [B, T, 1]
+            x = x + step + (step_2 - step) * mask
+        else:
+            x = x + self.diffusion_embedding(diffusion_step)
 
         for layer in self.residual_layers:
             x = layer(x)

--- a/modules/backbones/lynxnet2.py
+++ b/modules/backbones/lynxnet2.py
@@ -2,7 +2,14 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from modules.commons.common_layers import SinusoidalPosEmb, SwiGLU, ATanGLU, Transpose, AdamWLinear
+from modules.commons.common_layers import (
+    ATanGLU,
+    AdamWLinear,
+    SinusoidalPosEmb,
+    SwiGLU,
+    Transpose,
+    interpolate_dual_timestep_embedding,
+)
 from utils.hparams import hparams
 
 
@@ -95,15 +102,14 @@ class LYNXNet2(nn.Module):
             x = x + self.conditioner_projection(cond).transpose(1, 2)
         else:
             x = x + self.conditioner_projection(cond.transpose(1, 2))
-        
-        if mask is not None:
-            step = torch.cat((diffusion_step, diffusion_step_2), dim=0)
-            step = self.diffusion_embedding(step)
-            step, step_2 = torch.split(step, x.shape[0], dim=0) #[B, 1, C]
-            mask = mask.to(x).unsqueeze(-1) # [B, T, 1]
-            x = x + step + (step_2 - step) * mask
-        else:
-            x = x + self.diffusion_embedding(diffusion_step)
+
+        step = interpolate_dual_timestep_embedding(
+            self.diffusion_embedding,
+            diffusion_step,
+            diffusion_step_2,
+            mask,
+        )
+        x = x + step
 
         for layer in self.residual_layers:
             x = layer(x)

--- a/modules/backbones/wavenet.py
+++ b/modules/backbones/wavenet.py
@@ -26,7 +26,7 @@ class ResidualBlock(nn.Module):
         self.output_projection = nn.Conv1d(residual_channels, 2 * residual_channels, 1)
 
     def forward(self, x, conditioner, diffusion_step):
-        diffusion_step = self.diffusion_projection(diffusion_step).unsqueeze(-1)
+        diffusion_step = self.diffusion_projection(diffusion_step).transpose(1, 2)
         conditioner = self.conditioner_projection(conditioner)
         y = x + diffusion_step
 
@@ -67,7 +67,7 @@ class WaveNet(nn.Module):
         self.output_projection = AdamWConv1d(num_channels, in_dims * n_feats, 1)
         nn.init.zeros_(self.output_projection.weight)
 
-    def forward(self, spec, diffusion_step, cond):
+    def forward(self, spec, diffusion_step, cond, diffusion_step_2=None, mask=None):
         """
         :param spec: [B, F, M, T]
         :param diffusion_step: [B, 1]
@@ -84,11 +84,21 @@ class WaveNet(nn.Module):
         x = self.input_projection(x)  # [B, C, T]
 
         x = F.relu(x)
-        diffusion_step = self.diffusion_embedding(diffusion_step)
-        diffusion_step = self.mlp(diffusion_step)
+           
+        if mask is not None:
+            step = torch.cat((diffusion_step, diffusion_step_2), dim=0)
+            step = self.diffusion_embedding(step)
+            step = self.mlp(step)
+            step, step_2 = torch.split(step, x.shape[0], dim=0) #[B, 1, C]
+            mask = mask.to(x).unsqueeze(-1) # [B, T, 1]
+            step = step + (step_2 - step) * mask
+        else:
+            step = self.diffusion_embedding(diffusion_step)
+            step = self.mlp(step)
+            
         skip = []
         for layer in self.residual_layers:
-            x, skip_connection = layer(x, cond, diffusion_step)
+            x, skip_connection = layer(x, cond, step)
             skip.append(skip_connection)
 
         x = torch.sum(torch.stack(skip), dim=0) / sqrt(len(self.residual_layers))

--- a/modules/backbones/wavenet.py
+++ b/modules/backbones/wavenet.py
@@ -5,7 +5,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from modules.commons.common_layers import SinusoidalPosEmb, AdamWConv1d
+from modules.commons.common_layers import (
+    AdamWConv1d,
+    SinusoidalPosEmb,
+    interpolate_dual_timestep_embedding,
+)
 from modules.commons.common_layers import KaimingNormalConv1d as Conv1d
 from utils.hparams import hparams
 
@@ -84,18 +88,14 @@ class WaveNet(nn.Module):
         x = self.input_projection(x)  # [B, C, T]
 
         x = F.relu(x)
-           
-        if mask is not None:
-            step = torch.cat((diffusion_step, diffusion_step_2), dim=0)
-            step = self.diffusion_embedding(step)
-            step = self.mlp(step)
-            step, step_2 = torch.split(step, x.shape[0], dim=0) #[B, 1, C]
-            mask = mask.to(x).unsqueeze(-1) # [B, T, 1]
-            step = step + (step_2 - step) * mask
-        else:
-            step = self.diffusion_embedding(diffusion_step)
-            step = self.mlp(step)
-            
+
+        step = interpolate_dual_timestep_embedding(
+            lambda timestep: self.mlp(self.diffusion_embedding(timestep)),
+            diffusion_step,
+            diffusion_step_2,
+            mask,
+        )
+
         skip = []
         for layer in self.residual_layers:
             x, skip_connection = layer(x, cond, step)

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -422,6 +422,8 @@ class SinusoidalPosEmb(nn.Module):
         half_dim = self.dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, device=device) * -emb)
-        emb = x.unsqueeze(-1) * emb.unsqueeze(0)
+        if x.dim() == 1:
+            x = x.unsqueeze(-1)
+        emb = x.unsqueeze(-1) * emb
         emb = torch.cat((emb.sin(), emb.cos()), dim=-1)
         return emb

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+from typing import Callable
+
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -195,6 +197,25 @@ class Transpose(nn.Module):
 
     def forward(self, x):
         return x.transpose(*self.dims)
+
+
+def interpolate_dual_timestep_embedding(
+        embedding: nn.Module | Callable[[torch.Tensor], torch.Tensor],
+        timestep: torch.Tensor,
+        timestep_2: torch.Tensor | None = None,
+        mask: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Embed one or two timesteps and interpolate the second on masked frames."""
+    if mask is None:
+        return embedding(timestep)
+    if timestep_2 is None:
+        raise ValueError('timestep_2 is required when mask is provided')
+
+    batch_size = timestep.shape[0]
+    embedded = embedding(torch.cat((timestep, timestep_2), dim=0))
+    step, step_2 = torch.split(embedded, batch_size, dim=0)
+    frame_mask = mask.to(step).unsqueeze(-1)
+    return step + (step_2 - step) * frame_mask
 
 
 class Mixed_LayerNorm(nn.Module):

--- a/modules/core/reflow.py
+++ b/modules/core/reflow.py
@@ -18,6 +18,7 @@ class RectifiedFlow(nn.Module):
         self.velocity_fn: nn.Module = build_backbone(out_dims, num_feats, backbone_type, backbone_args)
         self.out_dims = out_dims
         self.num_feats = num_feats
+        self.use_dual_timestep = hparams.get('use_dual_timestep', False)
         self.use_shallow_diffusion = hparams.get('use_shallow_diffusion', False)
         if self.use_shallow_diffusion:
             assert 0. <= t_start <= 1., 'T_start should be in [0, 1].'
@@ -33,24 +34,34 @@ class RectifiedFlow(nn.Module):
         self.register_buffer('spec_min', spec_min, persistent=False)
         self.register_buffer('spec_max', spec_max, persistent=False)
 
-    def p_losses(self, x_end, t, cond):
+    def p_losses(self, x_end, t1, cond, t2=None, mask=None):
+        t = t1 if mask is None else t1 + (t2 - t1) * mask
         x_start = torch.randn_like(x_end)
-        x_t = x_start + t[:, None, None, None] * (x_end - x_start)
-        v_pred = self.velocity_fn(x_t, t * self.time_scale_factor, cond)
+        x_t = x_start + t[:, None, None,:] * (x_end - x_start)
+        s1 = t1 * self.time_scale_factor
+        s2 = None if t2 is None else t2 * self.time_scale_factor
+        v_pred = self.velocity_fn(x_t, s1, cond, s2, mask)
 
-        return v_pred, x_end - x_start
+        return v_pred, x_end - x_start, t
 
     def forward(self, condition, gt_spec=None, src_spec=None, infer=True):
         cond = condition.transpose(1, 2)
-        b, device = condition.shape[0], condition.device
+        b, _, n_frames = cond.shape
+        device = condition.device
 
         if not infer:
             # gt_spec: [B, T, M] or [B, F, T, M]
             spec = self.norm_spec(gt_spec).transpose(-2, -1)  # [B, M, T] or [B, F, M, T]
             if self.num_feats == 1:
                 spec = spec[:, None, :, :]  # [B, F=1, M, T]
-            t = self.t_start + (1.0 - self.t_start) * torch.rand((b,), device=device)
-            v_pred, v_gt = self.p_losses(spec, t, cond=cond)
+            t1 = self.t_start + (1.0 - self.t_start) * torch.rand((b, 1), device=device)
+            if self.use_dual_timestep:
+                t2 = self.t_start + (1.0 - self.t_start) * torch.rand((b, 1), device=device)
+                mask = (torch.rand(b, n_frames, device=device) < 0.25).float()
+            else:
+                t2 = None
+                mask = None
+            v_pred, v_gt, t = self.p_losses(spec, t1, cond=cond, t2=t2, mask=mask)
             return v_pred, v_gt, t
         else:
             # src_spec: [B, T, M] or [B, F, T, M]

--- a/modules/losses/reflow_loss.py
+++ b/modules/losses/reflow_loss.py
@@ -31,7 +31,7 @@ class RectifiedFlowLoss(nn.Module):
         weights = 0.398942 / t / (1 - t) * torch.exp(
             -0.5 * torch.log(t / (1 - t)) ** 2
         ) + eps
-        return weights[:, None, None, None]
+        return weights[:, None, None, :]
 
     def _forward(self, v_pred, v_gt, t=None):
         if self.log_norm:
@@ -43,7 +43,7 @@ class RectifiedFlowLoss(nn.Module):
         """
         :param v_pred: [B, 1, M, T]
         :param v_gt: [B, 1, M, T]
-        :param t: [B,]
+        :param t: [B, 1] or [B, T]
         :param non_padding: [B, T, M]
         """
         v_pred, v_gt = self._mask_non_padding(v_pred, v_gt, non_padding)


### PR DESCRIPTION
## Summary

Integrate the reviewed upstream openvpi/DiffSinger dual-timestep implementation on top of the clean openvpi/DiffSinger main baseline.

## Source

- Upstream branch: https://github.com/openvpi/DiffSinger/tree/dual-timestep
- Source commit: 72981e4d6a290228380d1fe9b31d6c22fd37becc

## Scope

- Add dual-timestep configuration for acoustic and variance models.
- Thread paired timesteps through WaveNet, LYNXNet, and LYNXNet2.
- Update reflow training and loss handling.

## Validation

Review and tests will be completed before this PR is merged into the integration branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dual-timestep diffusion processing, enabling interpolation between two diffusion steps on a per-frame basis.
  - Enabled dual-timestep mode in acoustic and variance configurations.
  - Improved model conditioning to support smoothly blended timestep information.

- **Bug Fixes**
  - Improved handling of timestep tensor shapes for more reliable training and loss calculations.
  - Added support for one-dimensional inputs in sinusoidal positional embeddings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->