### PR TITLE
feat: integrate Laurel blocks and configurable RoPE theta

### DIFF
--- a/configs/acoustic.yaml
+++ b/configs/acoustic.yaml
@@ -69,6 +69,8 @@ max_beta: 0.02
 enc_ffn_kernel_size: 3
 use_rope: true
 rope_interleaved: false
+rope_theta: 10000
+use_laurel_block: false
 use_stretch_embed: true
 use_variance_scaling: true
 rel_pos: true

--- a/configs/templates/config_acoustic.yaml
+++ b/configs/templates/config_acoustic.yaml
@@ -77,6 +77,8 @@ use_dual_timestep: true
 enc_ffn_kernel_size: 3
 use_rope: true
 rope_interleaved: false
+rope_theta: 10000
+use_laurel_block: false
 use_stretch_embed: true
 use_variance_scaling: true
 use_shallow_diffusion: true

--- a/configs/templates/config_variance.yaml
+++ b/configs/templates/config_variance.yaml
@@ -67,6 +67,8 @@ tension_logit_max: 10.0
 enc_ffn_kernel_size: 3
 use_rope: true
 rope_interleaved: false
+rope_theta: 10000
+use_laurel_block: false
 use_stretch_embed: false
 use_variance_scaling: true
 hidden_size: 384
@@ -86,6 +88,8 @@ use_melody_encoder: true
 melody_encoder_args:
   hidden_size: 128
   enc_layers: 4
+  rope_theta: 10000
+  use_laurel_block: false
 use_glide_embed: false
 glide_types: [up, down]
 glide_embed_scale: 11.313708498984760  # sqrt(128)

--- a/configs/variance.yaml
+++ b/configs/variance.yaml
@@ -37,6 +37,8 @@ predict_tension: false
 enc_ffn_kernel_size: 3
 use_rope: true
 rope_interleaved: false
+rope_theta: 10000
+use_laurel_block: false
 use_stretch_embed: false
 use_variance_scaling: true
 rel_pos: true
@@ -58,6 +60,8 @@ use_melody_encoder: true
 melody_encoder_args:
   hidden_size: 128
   enc_layers: 4
+  rope_theta: 10000
+  use_laurel_block: false
 use_glide_embed: false
 glide_types: [up, down]
 glide_embed_scale: 11.313708498984760  # sqrt(128)

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -464,8 +464,9 @@ class MultiheadSelfAttentionWithRoPE(nn.Module):
 
         return output
 
+
 class LaurelBlock(nn.Module):
-    """Laurel residual connection block"""
+    """Laurel residual connection block."""
     def __init__(self, dim, bottleneck_dim=64):
         super().__init__()
         self.down_proj = nn.Linear(dim, bottleneck_dim, bias=False)
@@ -479,10 +480,11 @@ class LaurelBlock(nn.Module):
         x = self.norm(x)
         return residual + x
 
+
 class EncSALayer(nn.Module):
     def __init__(self, c, num_heads, dropout, attention_dropout=0.1,
                  relu_dropout=0.1, kernel_size=9, act='gelu', rotary_embed=None,
-                 layer_idx=None, mix_ln_layer=None,use_laurel_block=False
+                 layer_idx=None, mix_ln_layer=None, use_laurel_block=False
                  ):
         super().__init__()
         self.dropout = dropout
@@ -511,7 +513,7 @@ class EncSALayer(nn.Module):
         self.ffn = TransformerFFNLayer(
             c, 4 * c, kernel_size=kernel_size, dropout=relu_dropout, act=act
         )
-        
+
         self.use_laurel_block = use_laurel_block
         if self.use_laurel_block:
             self.laurel = LaurelBlock(c)

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -482,7 +482,7 @@ class LaurelBlock(nn.Module):
 class EncSALayer(nn.Module):
     def __init__(self, c, num_heads, dropout, attention_dropout=0.1,
                  relu_dropout=0.1, kernel_size=9, act='gelu', rotary_embed=None,
-                 layer_idx=None, mix_ln_layer=None
+                 layer_idx=None, mix_ln_layer=None,use_laurel_block=False
                  ):
         super().__init__()
         self.dropout = dropout

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -464,6 +464,20 @@ class MultiheadSelfAttentionWithRoPE(nn.Module):
 
         return output
 
+class LaurelBlock(nn.Module):
+    """Laurel residual connection block"""
+    def __init__(self, dim, bottleneck_dim=64):
+        super().__init__()
+        self.down_proj = nn.Linear(dim, bottleneck_dim, bias=False)
+        self.up_proj = nn.Linear(bottleneck_dim, dim, bias=False)
+        self.norm = LayerNorm(dim)
+
+    def forward(self, x):
+        residual = x
+        x = self.down_proj(x)
+        x = self.up_proj(x)
+        x = self.norm(x)
+        return residual + x
 
 class EncSALayer(nn.Module):
     def __init__(self, c, num_heads, dropout, attention_dropout=0.1,
@@ -497,6 +511,10 @@ class EncSALayer(nn.Module):
         self.ffn = TransformerFFNLayer(
             c, 4 * c, kernel_size=kernel_size, dropout=relu_dropout, act=act
         )
+        
+        self.use_laurel_block = use_laurel_block
+        if self.use_laurel_block:
+            self.laurel = LaurelBlock(c)
 
     def forward(self, x, encoder_padding_mask=None, cond=None, **kwargs):
         layer_norm_training = kwargs.get('layer_norm_training', None)
@@ -512,6 +530,10 @@ class EncSALayer(nn.Module):
         x = F.dropout(x, self.dropout, training=self.training)
         x = residual + x
         x = x * (1 - encoder_padding_mask.float())[..., None]
+
+        if self.use_laurel_block:
+            x = self.laurel(x) * 0.707106781187 # sqrt(1/2)
+            x = x * (1 - encoder_padding_mask.float())[..., None]
 
         residual = x
         if self.use_mix_ln:

--- a/modules/fastspeech/acoustic_encoder.py
+++ b/modules/fastspeech/acoustic_encoder.py
@@ -44,7 +44,8 @@ class FastSpeech2Acoustic(nn.Module):
             dropout=hparams['dropout'], num_heads=hparams['num_heads'],
             use_pos_embed=hparams['use_pos_embed'], rel_pos=hparams.get('rel_pos', False),
             use_rope=hparams.get('use_rope', False), rope_interleaved=hparams.get('rope_interleaved', True),
-            mix_ln_layer=self.mix_ln_layer, rope_theta=hparams.get('rope_theta', 10000),use_laurel_block=hparams.get('use_laurel_block', False),
+            mix_ln_layer=self.mix_ln_layer, rope_theta=hparams.get('rope_theta', 10000),
+            use_laurel_block=hparams.get('use_laurel_block', False),
         )
 
         self.pitch_embed = AdamWLinear(1, hparams['hidden_size'])

--- a/modules/fastspeech/acoustic_encoder.py
+++ b/modules/fastspeech/acoustic_encoder.py
@@ -44,7 +44,7 @@ class FastSpeech2Acoustic(nn.Module):
             dropout=hparams['dropout'], num_heads=hparams['num_heads'],
             use_pos_embed=hparams['use_pos_embed'], rel_pos=hparams.get('rel_pos', False),
             use_rope=hparams.get('use_rope', False), rope_interleaved=hparams.get('rope_interleaved', True),
-            mix_ln_layer=self.mix_ln_layer
+            mix_ln_layer=self.mix_ln_layer, rope_theta=hparams.get('rope_theta', 10000),use_laurel_block=hparams.get('use_laurel_block', False),
         )
 
         self.pitch_embed = AdamWLinear(1, hparams['hidden_size'])

--- a/modules/fastspeech/tts_modules.py
+++ b/modules/fastspeech/tts_modules.py
@@ -373,7 +373,8 @@ class FastSpeech2Encoder(nn.Module):
             self, hidden_size, num_layers,
             ffn_kernel_size=9, ffn_act='gelu',
             dropout=None, num_heads=2, use_pos_embed=True, rel_pos=True,
-            use_rope=False, rope_interleaved=True, mix_ln_layer=None
+            use_rope=False, rope_interleaved=True, mix_ln_layer=None, rope_theta=10000,
+            use_laurel_block=False
     ):
         super().__init__()
         self.num_layers = num_layers
@@ -394,7 +395,7 @@ class FastSpeech2Encoder(nn.Module):
                 self.hidden_size, self.dropout,
                 kernel_size=ffn_kernel_size, act=ffn_act,
                 num_heads=num_heads, rotary_embed=rotary_embed,
-                layer_idx=i, mix_ln_layer=mix_ln_layer
+                layer_idx=i, mix_ln_layer=mix_ln_layer, use_laurel_block=use_laurel_block
             )
             for i in range(self.num_layers)
         ])

--- a/modules/fastspeech/tts_modules.py
+++ b/modules/fastspeech/tts_modules.py
@@ -13,14 +13,14 @@ DEFAULT_MAX_TARGET_POSITIONS = 2000
 
 class TransformerEncoderLayer(nn.Module):
     def __init__(self, hidden_size, dropout, kernel_size=None, act='gelu', num_heads=2, rotary_embed=None,
-                 layer_idx=None, mix_ln_layer=None):
+                 layer_idx=None, mix_ln_layer=None, use_laurel_block=False):
         super().__init__()
         self.op = EncSALayer(
             hidden_size, num_heads, dropout=dropout,
             attention_dropout=0.0, relu_dropout=dropout,
             kernel_size=kernel_size,
             act=act, rotary_embed=rotary_embed,
-            layer_idx=layer_idx, mix_ln_layer=mix_ln_layer
+            layer_idx=layer_idx, mix_ln_layer=mix_ln_layer,use_laurel_block=use_laurel_block
         )
 
     def forward(self, x, **kwargs):
@@ -387,7 +387,7 @@ class FastSpeech2Encoder(nn.Module):
                     "RoPE requires the hidden size to be multiple of "
                     f"num_heads * 2 = {num_heads * 2}, but got {embed_dim}."
                 )
-            rotary_embed = RotaryEmbedding(dim=embed_dim // num_heads, interleaved=rope_interleaved)
+            rotary_embed = RotaryEmbedding(dim=embed_dim // num_heads,theta=rope_theta, interleaved=rope_interleaved)
         else:
             rotary_embed = None
         self.layers = nn.ModuleList([

--- a/modules/fastspeech/tts_modules.py
+++ b/modules/fastspeech/tts_modules.py
@@ -20,7 +20,8 @@ class TransformerEncoderLayer(nn.Module):
             attention_dropout=0.0, relu_dropout=dropout,
             kernel_size=kernel_size,
             act=act, rotary_embed=rotary_embed,
-            layer_idx=layer_idx, mix_ln_layer=mix_ln_layer,use_laurel_block=use_laurel_block
+            layer_idx=layer_idx, mix_ln_layer=mix_ln_layer,
+            use_laurel_block=use_laurel_block
         )
 
     def forward(self, x, **kwargs):
@@ -387,7 +388,9 @@ class FastSpeech2Encoder(nn.Module):
                     "RoPE requires the hidden size to be multiple of "
                     f"num_heads * 2 = {num_heads * 2}, but got {embed_dim}."
                 )
-            rotary_embed = RotaryEmbedding(dim=embed_dim // num_heads,theta=rope_theta, interleaved=rope_interleaved)
+            rotary_embed = RotaryEmbedding(
+                dim=embed_dim // num_heads, theta=rope_theta, interleaved=rope_interleaved
+            )
         else:
             rotary_embed = None
         self.layers = nn.ModuleList([

--- a/modules/fastspeech/variance_encoder.py
+++ b/modules/fastspeech/variance_encoder.py
@@ -34,7 +34,8 @@ class FastSpeech2Variance(nn.Module):
             ffn_kernel_size=hparams['enc_ffn_kernel_size'], ffn_act=hparams['ffn_act'],
             dropout=hparams['dropout'], num_heads=hparams['num_heads'],
             use_pos_embed=hparams['use_pos_embed'], rel_pos=hparams.get('rel_pos', False), 
-            use_rope=hparams.get('use_rope', False), rope_interleaved=hparams.get('rope_interleaved', True)
+            use_rope=hparams.get('use_rope', False), rope_interleaved=hparams.get('rope_interleaved', True), 
+            rope_theta=hparams.get('rope_theta', 10000),use_laurel_block=hparams.get('use_laurel_block', False),
         )
 
         dur_hparams = hparams['dur_prediction_args']

--- a/modules/fastspeech/variance_encoder.py
+++ b/modules/fastspeech/variance_encoder.py
@@ -109,8 +109,8 @@ class MelodyEncoder(nn.Module):
     def __init__(self, enc_hparams: dict):
         super().__init__()
 
-        def get_hparam(key):
-            return enc_hparams.get(key, hparams.get(key))
+        def get_hparam(key, default=None):
+            return enc_hparams.get(key, hparams.get(key, default))
 
         # MIDI inputs
         hidden_size = get_hparam('hidden_size')
@@ -130,7 +130,10 @@ class MelodyEncoder(nn.Module):
             ffn_kernel_size=get_hparam('enc_ffn_kernel_size'), ffn_act=get_hparam('ffn_act'),
             dropout=get_hparam('dropout'), num_heads=get_hparam('num_heads'),
             use_pos_embed=get_hparam('use_pos_embed'), rel_pos=get_hparam('rel_pos'),
-            use_rope=get_hparam('use_rope'), rope_interleaved=hparams.get('rope_interleaved', True)
+            use_rope=get_hparam('use_rope'),
+            rope_interleaved=get_hparam('rope_interleaved', True),
+            rope_theta=get_hparam('rope_theta', 10000),
+            use_laurel_block=get_hparam('use_laurel_block', False),
         )
         self.out_proj = Linear(hidden_size, hparams['hidden_size'])
 

--- a/modules/fastspeech/variance_encoder.py
+++ b/modules/fastspeech/variance_encoder.py
@@ -33,9 +33,10 @@ class FastSpeech2Variance(nn.Module):
             hidden_size=hparams['hidden_size'], num_layers=hparams['enc_layers'],
             ffn_kernel_size=hparams['enc_ffn_kernel_size'], ffn_act=hparams['ffn_act'],
             dropout=hparams['dropout'], num_heads=hparams['num_heads'],
-            use_pos_embed=hparams['use_pos_embed'], rel_pos=hparams.get('rel_pos', False), 
-            use_rope=hparams.get('use_rope', False), rope_interleaved=hparams.get('rope_interleaved', True), 
-            rope_theta=hparams.get('rope_theta', 10000),use_laurel_block=hparams.get('use_laurel_block', False),
+            use_pos_embed=hparams['use_pos_embed'], rel_pos=hparams.get('rel_pos', False),
+            use_rope=hparams.get('use_rope', False), rope_interleaved=hparams.get('rope_interleaved', True),
+            rope_theta=hparams.get('rope_theta', 10000),
+            use_laurel_block=hparams.get('use_laurel_block', False),
         )
 
         dur_hparams = hparams['dur_prediction_args']


### PR DESCRIPTION
## Summary

Integrate optional Laurel encoder residual blocks together with configurable RoPE theta on top of the current integration branch.

## Source

- Feature commit: 74aea1251c863537bb6cc14e422e551acdfca004
- Required follow-up fix: 2e4d59720dbfcb31648a089b4b5ac6a820428dd7

## Scope

- Add optional Laurel residual blocks to FastSpeech encoder layers.
- Thread use_laurel_block through acoustic, variance, and melody encoders.
- Add configurable rope_theta handling to acoustic, variance, and melody encoders.
- Expose rope_theta and use_laurel_block in acoustic/variance configs and templates; melody_encoder_args may override them independently.
- Address CodeRabbit feedback for the second FastSpeech2Encoder construction in MelodyEncoder.

## Validation

- Python compileall for modules/: passed.
- git diff --check: passed.