### PR TITLE
feat: adjust AdamW routing and LYNXNet2 FP16 LayerNorm

### DIFF
--- a/modules/backbones/lynxnet.py
+++ b/modules/backbones/lynxnet.py
@@ -45,7 +45,7 @@ class LYNXConvModule(nn.Module):
             Transpose((1, 2)),
             nn.Conv1d(dim, inner_dim * 2, 1),
             SwiGLU(dim=1),
-            nn.Conv1d(inner_dim, inner_dim, kernel_size=kernel_size, padding=padding[0], groups=inner_dim),
+            AdamWConv1d(inner_dim, inner_dim, kernel_size=kernel_size, padding=padding[0], groups=inner_dim),
             _activation,
             nn.Conv1d(inner_dim, dim, 1),
             Transpose((1, 2)),

--- a/modules/backbones/lynxnet2.py
+++ b/modules/backbones/lynxnet2.py
@@ -4,8 +4,10 @@ import torch.nn.functional as F
 
 from modules.commons.common_layers import (
     ATanGLU,
+    AdamWConv1d,
     AdamWLinear,
     DoubleSoftSignGLU,
+    FP16LayerNorm,
     SinusoidalPosEmb,
     SoftSignGLU,
     SwiGLU,
@@ -34,9 +36,9 @@ class LYNXNet2Block(nn.Module):
         else:
             _dropout = nn.Identity()
         self.net = nn.Sequential(
-            nn.LayerNorm(dim),
+            FP16LayerNorm(dim),
             Transpose((1, 2)),
-            nn.Conv1d(dim, dim, kernel_size=kernel_size, padding=kernel_size // 2, groups=dim),
+            AdamWConv1d(dim, dim, kernel_size=kernel_size, padding=kernel_size // 2, groups=dim),
             Transpose((1, 2)),
             nn.Linear(dim, inner_dim * 2),
             _glu,

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -43,6 +43,32 @@ class AdamWLinear(torch.nn.Linear):
             nn.init.constant_(self.bias, 0.)
 
 
+class FP16LayerNorm(torch.nn.LayerNorm):
+    """Run LayerNorm entirely in FP16 during CUDA FP16 training."""
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if not self.training or not input.is_cuda:
+            return super().forward(input)
+
+        target_dtype = input.dtype
+        if torch.is_autocast_enabled():
+            target_dtype = torch.get_autocast_gpu_dtype()
+        if target_dtype != torch.float16:
+            return super().forward(input)
+
+        with torch.autocast(device_type='cuda', enabled=False):
+            input_fp16 = input.to(dtype=torch.float16)
+            weight_fp16 = None if self.weight is None else self.weight.to(dtype=torch.float16)
+            bias_fp16 = None if self.bias is None else self.bias.to(dtype=torch.float16)
+            return F.layer_norm(
+                input_fp16,
+                self.normalized_shape,
+                weight_fp16,
+                bias_fp16,
+                self.eps,
+            )
+
+
 class XavierUniformInitLinear(torch.nn.Linear):
     def __init__(
             self,
@@ -469,8 +495,8 @@ class LaurelBlock(nn.Module):
     """Laurel residual connection block."""
     def __init__(self, dim, bottleneck_dim=64):
         super().__init__()
-        self.down_proj = nn.Linear(dim, bottleneck_dim, bias=False)
-        self.up_proj = nn.Linear(bottleneck_dim, dim, bias=False)
+        self.down_proj = AdamWLinear(dim, bottleneck_dim, bias=False)
+        self.up_proj = AdamWLinear(bottleneck_dim, dim, bias=False)
         self.norm = LayerNorm(dim)
 
     def forward(self, x):


### PR DESCRIPTION
## Summary

Apply the requested optimizer-routing and precision policy changes on top of the merged Laurel/RoPE integration.

## Changes

- LaurelBlock down/up Linear projections now use AdamWLinear and are excluded from Muon routing.
- LYNXNet depthwise convolution now uses AdamWConv1d.
- LYNXNet2 depthwise convolution now uses AdamWConv1d.
- LYNXNet2 block pre-LayerNorm uses FP16LayerNorm, which explicitly runs the normalization operation, affine weight, and bias in FP16 during CUDA FP16 training.
- CPU, evaluation, BF16, and FP32 paths retain standard torch LayerNorm behavior.

## Validation

- Python compileall for modules/: passed.
- git diff --check: passed.
- Runtime CUDA tests were not run locally because the isolated Python environment does not include PyTorch.