### PR TITLE
revert: drop custom FP16 LayerNorm policy

### DIFF
--- a/modules/backbones/lynxnet2.py
+++ b/modules/backbones/lynxnet2.py
@@ -7,7 +7,6 @@ from modules.commons.common_layers import (
     AdamWConv1d,
     AdamWLinear,
     DoubleSoftSignGLU,
-    FP16LayerNorm,
     SinusoidalPosEmb,
     SoftSignGLU,
     SwiGLU,
@@ -36,7 +35,7 @@ class LYNXNet2Block(nn.Module):
         else:
             _dropout = nn.Identity()
         self.net = nn.Sequential(
-            FP16LayerNorm(dim),
+            nn.LayerNorm(dim),
             Transpose((1, 2)),
             AdamWConv1d(dim, dim, kernel_size=kernel_size, padding=kernel_size // 2, groups=dim),
             Transpose((1, 2)),

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -43,32 +43,6 @@ class AdamWLinear(torch.nn.Linear):
             nn.init.constant_(self.bias, 0.)
 
 
-class FP16LayerNorm(torch.nn.LayerNorm):
-    """Run LayerNorm entirely in FP16 during CUDA FP16 training."""
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        if not self.training or not input.is_cuda:
-            return super().forward(input)
-
-        target_dtype = input.dtype
-        if torch.is_autocast_enabled():
-            target_dtype = torch.get_autocast_gpu_dtype()
-        if target_dtype != torch.float16:
-            return super().forward(input)
-
-        with torch.autocast(device_type='cuda', enabled=False):
-            input_fp16 = input.to(dtype=torch.float16)
-            weight_fp16 = None if self.weight is None else self.weight.to(dtype=torch.float16)
-            bias_fp16 = None if self.bias is None else self.bias.to(dtype=torch.float16)
-            return F.layer_norm(
-                input_fp16,
-                self.normalized_shape,
-                weight_fp16,
-                bias_fp16,
-                self.eps,
-            )
-
-
 class XavierUniformInitLinear(torch.nn.Linear):
     def __init__(
             self,


### PR DESCRIPTION
## Summary

Abandon the custom FP16LayerNorm policy after reviewing its actual CUDA semantics.

## Changes

- Restore standard nn.LayerNorm in LYNXNet2 blocks.
- Remove the unused FP16LayerNorm wrapper.
- Keep all requested AdamW routing changes:
  - Laurel down/up projections remain AdamWLinear.
  - LYNXNet depthwise convolution remains AdamWConv1d.
  - LYNXNet2 depthwise convolution remains AdamWConv1d.

## Review

This rollback was explicitly requested after confirming PyTorch native CUDA LayerNorm still uses FP32 accumulators internally for Half inputs.

## Validation

- Python compileall for modules/: passed.
- git diff --check: passed.
- No FP16LayerNorm references remain.