### PR TITLE
revert: remove repeat-bin Forward XM

### DIFF
--- a/configs/templates/config_variance.yaml
+++ b/configs/templates/config_variance.yaml
@@ -125,10 +125,6 @@ lambda_dur_loss: 1.0
 lambda_pitch_loss: 1.0
 lambda_var_loss: 1.0
 
-# Explorative Modeling for Rectified Flow predictors.
-xm_pitch_best_of_k: 1
-xm_variance_best_of_k: 1
-
 optimizer_args:
   optimizer_cls: modules.optimizer.muon.Muon_AdamW
   lr: 0.0006

--- a/configs/variance.yaml
+++ b/configs/variance.yaml
@@ -118,11 +118,6 @@ lambda_dur_loss: 1.0
 lambda_pitch_loss: 1.0
 lambda_var_loss: 1.0
 
-# Explorative Modeling for Rectified Flow predictors. K=1 preserves the
-# standard objective. Pitch and variance can be enabled independently.
-xm_pitch_best_of_k: 1
-xm_variance_best_of_k: 1
-
 diffusion_type: reflow  # ddpm
 use_dual_timestep: true
 time_scale_factor: 1000

--- a/modules/losses/reflow_loss.py
+++ b/modules/losses/reflow_loss.py
@@ -41,51 +41,10 @@ class RectifiedFlowLoss(nn.Module):
 
     def forward(self, v_pred: Tensor, v_gt: Tensor, t: Tensor, non_padding: Tensor = None) -> Tensor:
         """
-        :param v_pred: [B, F, R, T]
-        :param v_gt: [B, F, R, T]
+        :param v_pred: [B, 1, M, T]
+        :param v_gt: [B, 1, M, T]
         :param t: [B, 1] or [B, T]
         :param non_padding: [B, T, M]
         """
         v_pred, v_gt = self._mask_non_padding(v_pred, v_gt, non_padding)
         return self._forward(v_pred, v_gt, t=t).mean()
-
-    def forward_best_bin(
-            self, v_pred: Tensor, v_gt: Tensor, t: Tensor,
-            non_padding: Tensor = None, k: int = 1,
-    ) -> Tensor:
-        """Best-of-k over the repeat-bin dimension with zero extra compute.
-
-        RepetitiveRectifiedFlow already assigns each bin an independent noise,
-        so the R bins are R natural Forward XM candidates. This selects the
-        k lowest-loss bins per (batch, feature), averages over them, and
-        backpropagates only through those k bins.
-        """
-        v_pred, v_gt = self._mask_non_padding(v_pred, v_gt, non_padding)
-        loss = self._forward(v_pred, v_gt, t=t)  # [B, F, R, T]
-
-        per_bin = loss.sum(dim=-1)  # [B, F, R]
-        if non_padding is not None:
-            mask = non_padding.transpose(1, 2).unsqueeze(1).to(loss)
-            mask_sum = mask.sum(dim=-1)  # [B, 1, 1]
-            mask_sum = mask_sum.expand_as(per_bin).clamp_min(1.)
-            per_bin = per_bin / mask_sum
-
-        num_bins = per_bin.shape[-1]
-        k = min(k, num_bins)
-        if k >= num_bins:
-            return loss.mean()
-
-        # Select the k best bins per (batch, feature)
-        topk_values, topk_indices = per_bin.topk(k, dim=-1, largest=False)  # [B, F, k]
-
-        # Gather the winning predictions and targets
-        gather_indices = topk_indices.unsqueeze(-1).expand(-1, -1, -1, v_gt.shape[-1])
-        best_pred = v_pred.gather(2, gather_indices)  # [B, F, k, T]
-        best_gt = v_gt.gather(2, gather_indices)  # [B, F, k, T]
-
-        best_loss = self.loss(best_pred, best_gt)  # [B, F, k, T]
-        if self.log_norm:
-            best_loss = self.get_weights(t).squeeze(2).unsqueeze(2) * best_loss
-        if non_padding is not None:
-            best_loss = best_loss * non_padding.transpose(1, 2).unsqueeze(2)
-        return best_loss.mean()

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -113,13 +113,6 @@ class VarianceTask(BaseTask):
             self.variance_prediction_list.append('tension')
         self.predict_variances = len(self.variance_prediction_list) > 0
         self.lambda_var_loss = hparams['lambda_var_loss']
-        self.xm_pitch_best_of_k = int(hparams.get('xm_pitch_best_of_k', 1))
-        self.xm_variance_best_of_k = int(hparams.get('xm_variance_best_of_k', 1))
-        if min(self.xm_pitch_best_of_k, self.xm_variance_best_of_k) < 1:
-            raise ValueError('XM best-of-K values must be at least 1.')
-        if (self.xm_pitch_best_of_k > 1 or self.xm_variance_best_of_k > 1) \
-                and self.diffusion_type != 'reflow':
-            raise ValueError('Explorative Modeling currently supports Rectified Flow only.')
         super()._finish_init()
 
         # ── Fuse LYNXNet2 backbone kernels (in-place) ──
@@ -316,14 +309,9 @@ class VarianceTask(BaseTask):
                     )
                 elif self.diffusion_type == 'reflow':
                     pitch_v_pred, pitch_v_gt, t = pitch_pred
-                    if self.xm_pitch_best_of_k > 1:
-                        pitch_loss = self.pitch_loss.forward_best_bin(
-                            pitch_v_pred, pitch_v_gt, t=t, non_padding=non_padding
-                        )
-                    else:
-                        pitch_loss = self.pitch_loss(
-                            pitch_v_pred, pitch_v_gt, t=t, non_padding=non_padding
-                        )
+                    pitch_loss = self.pitch_loss(
+                        pitch_v_pred, pitch_v_gt, t=t, non_padding=non_padding
+                    )
                 else:
                     raise ValueError(f"Unknown diffusion type: {self.diffusion_type}")
                 losses['pitch_loss'] = self.lambda_pitch_loss * pitch_loss
@@ -335,14 +323,9 @@ class VarianceTask(BaseTask):
                     )
                 elif self.diffusion_type == 'reflow':
                     var_v_pred, var_v_gt, t = variances_pred
-                    if self.xm_variance_best_of_k > 1:
-                        var_loss = self.var_loss.forward_best_bin(
-                            var_v_pred, var_v_gt, t=t, non_padding=non_padding
-                        )
-                    else:
-                        var_loss = self.var_loss(
-                            var_v_pred, var_v_gt, t=t, non_padding=non_padding
-                        )
+                    var_loss = self.var_loss(
+                        var_v_pred, var_v_gt, t=t, non_padding=non_padding
+                    )
                 else:
                     raise ValueError(f"Unknown diffusion type: {self.diffusion_type}")
                 losses['var_loss'] = self.lambda_var_loss * var_loss


### PR DESCRIPTION
## Summary

Reverts PR #58 in full.

The repeat-bin best-of-k approach leaves persistently under-selected bins effectively untrained. Since inference/evaluation averages all repeat bins, those undertrained bins degrade the final pitch/variance curves substantially. This violates the core assumption of the repeat-bin mechanism, where every bin must remain trained to preserve smooth averaged outputs.

This revert restores the exact state of `integration-dual-timestep-stack` before PR #58:

- removes `forward_best_bin`
- removes all XM configuration keys
- restores original repeat-bin counts
- restores mean-over-all-bins training for pitch and variance

## Verification

- `git diff 31bf62f4..HEAD`: empty
- `compileall modules training`: passed
- `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified variance and pitch training by removing experimental best-of-K prediction options.
  - Standardized rectified-flow loss handling for clearer, more consistent training behavior.
  - Updated loss documentation to reflect the current prediction and target format.

- **Chores**
  - Removed obsolete exploratory settings from variance configuration templates and training configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->