### PR TITLE
feat: MDNv2 duration predictor (GMM head + NLL loss)

### DIFF
--- a/configs/templates/config_duration.yaml
+++ b/configs/templates/config_duration.yaml
@@ -79,6 +79,20 @@ lambda_sdp_loss: 0.005
 lambda_sdp_reg_loss: 0.1
 sdp_reg_warmup_steps: 16000
 
+# MDN (Mixture Density Network) duration predictor
+# use_mdn: true replaces the single-Gaussian regression head with a GMM
+# of `num_gaussians` components trained by negative log-likelihood (NLL).
+# At inference the most probable component's mean is chosen deterministically,
+# so the ONNX interface {encoder_out, x_masks, ph_midi} -> {ph_dur_pred} is preserved.
+use_mdn: false
+mdn_args:
+  num_gaussians: 8
+  log_p_min: -7.0
+  log_sigma_min: -7.0
+  log_scale_max: 3.0
+  log_scale_min: -1.0
+  sigma_floor: 0.000001
+
 dur_prediction_args:
   arch: resnet
   hidden_size: 256

--- a/configs/templates/config_duration.yaml
+++ b/configs/templates/config_duration.yaml
@@ -89,7 +89,7 @@ mdn_args:
   num_gaussians: 8
   log_p_min: -7.0
   log_sigma_min: -7.0
-  log_scale_max: 3.0
+  log_scale_max: 6.0
   log_scale_min: -1.0
   sigma_floor: 0.000001
 

--- a/configs/templates/config_variance.yaml
+++ b/configs/templates/config_variance.yaml
@@ -84,6 +84,16 @@ dur_prediction_args:
   lambda_wdur_loss: 1.0
   lambda_sdur_loss: 3.0
 
+# MDN (Mixture Density Network) duration prediction
+use_mdn: false
+mdn_args:
+  num_gaussians: 8
+  log_p_min: -7.0
+  log_sigma_min: -7.0
+  log_scale_max: 3.0
+  log_scale_min: -1.0
+  sigma_floor: 0.000001
+
 use_melody_encoder: true
 melody_encoder_args:
   hidden_size: 128

--- a/configs/templates/config_variance.yaml
+++ b/configs/templates/config_variance.yaml
@@ -90,7 +90,7 @@ mdn_args:
   num_gaussians: 8
   log_p_min: -7.0
   log_sigma_min: -7.0
-  log_scale_max: 3.0
+  log_scale_max: 6.0
   log_scale_min: -1.0
   sigma_floor: 0.000001
 

--- a/configs/variance.yaml
+++ b/configs/variance.yaml
@@ -70,7 +70,7 @@ mdn_args:
   num_gaussians: 8
   log_p_min: -7.0
   log_sigma_min: -7.0
-  log_scale_max: 3.0
+  log_scale_max: 6.0
   log_scale_min: -1.0
   sigma_floor: 0.000001
 

--- a/configs/variance.yaml
+++ b/configs/variance.yaml
@@ -64,6 +64,16 @@ lambda_sdp_loss: 0.005
 lambda_sdp_reg_loss: 0.1
 sdp_reg_warmup_steps: 16000
 
+# MDN (Mixture Density Network) duration prediction
+use_mdn: false
+mdn_args:
+  num_gaussians: 8
+  log_p_min: -7.0
+  log_sigma_min: -7.0
+  log_scale_max: 3.0
+  log_scale_min: -1.0
+  sigma_floor: 0.000001
+
 use_melody_encoder: true
 melody_encoder_args:
   hidden_size: 128

--- a/modules/fastspeech/tts_modules.py
+++ b/modules/fastspeech/tts_modules.py
@@ -7,7 +7,7 @@ from modules.commons.rotary_embedding_torch import RotaryEmbedding
 from modules.commons.common_layers import SinusoidalPositionalEmbedding, EncSALayer, AdamWLinear
 from modules.commons.espnet_positional_embedding import RelPositionalEncoding
 from modules.sdp.sdp import StochasticDurationPredictor
-from modules.mdn.mdn import MDNLayer
+from modules.mdn.mdn import MDNLayer, mdn_nll_loss
 
 DEFAULT_MAX_SOURCE_POSITIONS = 2000
 DEFAULT_MAX_TARGET_POSITIONS = 2000
@@ -202,24 +202,29 @@ class DurationPredictor(torch.nn.Module):
 
         dp_feat = dp_xs.transpose(1, -1)             # [B, idim, Tmax] -> [B, Tmax, n_chans]
 
+        loss_sdp = 0.0
+        sdp_pred = None
+
         # ---- output head --------------------------------------------------
         if self.use_mdn:
-            # record raw log-domain mixture params; also give a linear-domain
-            # deterministic point estimate for downstream (mel2ph) building.
-            self._mdn_logit_p, self._mdn_log_sigma, self._mdn_mu = \
-                self.mdn(dp_feat)
-            log_mu_map = self.mdn.point_estimate(
-                self._mdn_logit_p, self._mdn_log_sigma, self._mdn_mu
-            )
+            # raw log-domain mixture params; the point estimate (mean of the
+            # most probable component) is the deterministic linear-domain
+            # prediction used for downstream mel2ph building.
+            logit_p, log_sigma, mu = self.mdn(dp_feat)
+            log_mu_map = self.mdn.point_estimate(logit_p, log_sigma, mu)
             dur_pred = log_mu_map.exp() - self.offset  # linear domain [B, Tmax]
             dur_pred = dur_pred * non_pad_mask_2d.squeeze(-1)
+            # MDN is trained by NLL on the log-domain target. Reuse the
+            # `loss_sdp` slot (mutually exclusive with use_sdp) to carry the
+            # masked per-phoneme NLL back to the training task.
+            if not infer and ph_dur is not None:
+                log_dur_gt = torch.log(ph_dur.float() + self.offset)
+                nll = mdn_nll_loss(self.mdn, logit_p, log_sigma, mu, log_dur_gt, masks=x_masks)
+                loss_sdp = nll.sum() / (non_pad_mask.sum() + 1e-8)
         else:
             dp_xs = self.linear(dp_feat)             # [B, Tmax, C]
             dp_xs = dp_xs * non_pad_mask_2d          # Mask padded areas [B, Tmax, C]
             dur_pred = self.out2dur(dp_xs)           # Convert to linear domain [B, Tmax]
-
-        loss_sdp = 0.0
-        sdp_pred = None
 
         if self.use_sdp and sdp_cond is not None:
             sdp_cond_t = sdp_cond.transpose(1, -1)   # [B, idim, Tmax]

--- a/modules/fastspeech/tts_modules.py
+++ b/modules/fastspeech/tts_modules.py
@@ -7,6 +7,7 @@ from modules.commons.rotary_embedding_torch import RotaryEmbedding
 from modules.commons.common_layers import SinusoidalPositionalEmbedding, EncSALayer, AdamWLinear
 from modules.commons.espnet_positional_embedding import RelPositionalEncoding
 from modules.sdp.sdp import StochasticDurationPredictor
+from modules.mdn.mdn import MDNLayer
 
 DEFAULT_MAX_SOURCE_POSITIONS = 2000
 DEFAULT_MAX_TARGET_POSITIONS = 2000
@@ -67,7 +68,8 @@ class DurationPredictor(torch.nn.Module):
 
     def __init__(self, in_dims, n_layers=2, n_chans=384, kernel_size=3,
                  dropout_rate=0.1, offset=1.0, dur_loss_type='mse', arch='resnet',
-                 use_sdp=False, sdp_ratio=0.2, sdp_n_chans=192, gin_channels=0):
+                 use_sdp=False, sdp_ratio=0.2, sdp_n_chans=192, gin_channels=0,
+                 use_mdn=False, mdn_args=None):
         """Initialize duration predictor module.
         Args:
             in_dims (int): Input dimension.
@@ -82,6 +84,9 @@ class DurationPredictor(torch.nn.Module):
             sdp_ratio (float, optional): Interpolation ratio between SDP and DP outputs during inference.
             sdp_n_chans (int, optional): Hidden channels for SDP.
             gin_channels (int, optional): Speaker embedding channels for SDP conditioning.
+            use_mdn (bool, optional): Use a Gaussian mixture head (NLL) instead of a
+                single-Gaussian regression head. Mutually exclusive with use_sdp.
+            mdn_args (dict, optional): MDN hyper-parameters (num_gaussians, clamps...).
         """
         super(DurationPredictor, self).__init__()
         self.offset = offset
@@ -121,12 +126,28 @@ class DurationPredictor(torch.nn.Module):
         #     self.crf = CRF(out_dims, batch_first=True)
         else:
             raise NotImplementedError()
-        self.linear = AdamWLinear(n_chans, self.out_dims)
+
+        self.use_mdn = use_mdn
+        self.mdn_args = mdn_args or {}
+        if self.use_mdn:
+            self.mdn = MDNLayer(
+                in_features=n_chans,
+                num_gaussians=self.mdn_args.get('num_gaussians', 8),
+                log_p_min=float(self.mdn_args.get('log_p_min', -7.0)),
+                log_sigma_min=float(self.mdn_args.get('log_sigma_min', -7.0)),
+                sigma_floor=float(self.mdn_args.get('sigma_floor', 1e-6)),
+                log_scale_max=float(self.mdn_args.get('log_scale_max', 3.0)),
+                log_scale_min=float(self.mdn_args.get('log_scale_min', -1.0)),
+            )
+            self.linear = None
+        else:
+            self.linear = AdamWLinear(n_chans, self.out_dims)
 
         self.use_sdp = use_sdp
         self.sdp_ratio = sdp_ratio
 
         if self.use_sdp:
+            assert not self.use_mdn, 'use_sdp and use_mdn are mutually exclusive'
             self.sdp = StochasticDurationPredictor(
                 in_channels=in_dims,
                 filter_channels=sdp_n_chans,
@@ -179,10 +200,23 @@ class DurationPredictor(torch.nn.Module):
             if x_masks is not None:
                 dp_xs = dp_xs * non_pad_mask_1d
 
-        dp_xs = self.linear(dp_xs.transpose(1, -1))  # [B, idim, Tmax] -> [B, Tmax, C]
-        dp_xs = dp_xs * non_pad_mask_2d              # Mask padded areas [B, Tmax, C]
+        dp_feat = dp_xs.transpose(1, -1)             # [B, idim, Tmax] -> [B, Tmax, n_chans]
 
-        dur_pred = self.out2dur(dp_xs)               # Convert to linear domain [B, Tmax]
+        # ---- output head --------------------------------------------------
+        if self.use_mdn:
+            # record raw log-domain mixture params; also give a linear-domain
+            # deterministic point estimate for downstream (mel2ph) building.
+            self._mdn_logit_p, self._mdn_log_sigma, self._mdn_mu = \
+                self.mdn(dp_feat)
+            log_mu_map = self.mdn.point_estimate(
+                self._mdn_logit_p, self._mdn_log_sigma, self._mdn_mu
+            )
+            dur_pred = log_mu_map.exp() - self.offset  # linear domain [B, Tmax]
+            dur_pred = dur_pred * non_pad_mask_2d.squeeze(-1)
+        else:
+            dp_xs = self.linear(dp_feat)             # [B, Tmax, C]
+            dp_xs = dp_xs * non_pad_mask_2d          # Mask padded areas [B, Tmax, C]
+            dur_pred = self.out2dur(dp_xs)           # Convert to linear domain [B, Tmax]
 
         loss_sdp = 0.0
         sdp_pred = None

--- a/modules/fastspeech/variance_encoder.py
+++ b/modules/fastspeech/variance_encoder.py
@@ -55,6 +55,8 @@ class FastSpeech2Variance(nn.Module):
                 sdp_ratio=hparams.get('sdp_ratio', 0.2),
                 sdp_n_chans=hparams.get('sdp_n_chans', 192),
                 gin_channels=hparams['hidden_size'] if hparams['use_spk_id'] else 0,
+                use_mdn=hparams.get('use_mdn', False),
+                mdn_args=hparams.get('mdn_args', None),
             )
 
     def forward(

--- a/modules/mdn/mdn.py
+++ b/modules/mdn/mdn.py
@@ -40,7 +40,7 @@ class MDNLayer(nn.Module):
 
     def __init__(self, in_features, num_gaussians=8,
                  log_p_min=-7.0, log_sigma_min=-7.0, sigma_floor=1e-6,
-                 log_scale_max=3.0, log_scale_min=-1.0):
+                 log_scale_max=6.0, log_scale_min=-1.0):
         super().__init__()
         self.in_features = in_features
         self.num_gaussians = num_gaussians
@@ -85,7 +85,7 @@ class MDNLayer(nn.Module):
         t = target.unsqueeze(-1)                   # [B, T, 1]
         log_n = (-0.5 * (torch.log(s * s) + _LOG_2PI)
                  - (t - mu) ** 2 / (2 * s * s))    # [B, T, G]
-        return logsumexp(log_n + lp, dim=-1)       # [B, T]
+        return logsumexp(log_n + lp, dim=-1, keepdim=False)  # [B, T]
 
     def point_estimate(self, logit_p, log_sigma, mu):
         """Deterministic point: mean of most-probable component. [B, T]."""
@@ -95,14 +95,16 @@ class MDNLayer(nn.Module):
         return m
 
 
-def mdn_nll_loss(logit_p, log_sigma, mu, target, masks=None):
-    """Per-phoneme NLL (log domain). target: [B, T]; returns [B, T]."""
-    tgt = target.unsqueeze(-1)                     # [B, T, 1]
-    lp = log_softmax(logit_p)                      # [B, T, G]
-    s = torch.clamp(log_sigma, min=-7.0).exp() + 1e-6
-    log_n = (-0.5 * (torch.log(s * s) + _LOG_2PI)
-             - (tgt - mu) ** 2 / (2 * s * s))
-    nll = -(logsumexp(log_n + lp, dim=-1, keepdim=False))  # [B, T]
+def mdn_nll_loss(mdn_layer, logit_p, log_sigma, mu, target, masks=None):
+    """Per-phoneme NLL (log domain), delegating density math to the layer.
+
+    :param mdn_layer: MDNLayer instance (its configured clamps are used).
+    :param logit_p, log_sigma, mu: mixture parameters from MDNLayer.forward.
+    :param target: log-domain durations [B, T].
+    :param masks: [B, T] bool tensor where True marks padding (excluded from loss).
+    :return: per-phoneme NLL [B, T].
+    """
+    nll = -mdn_layer.log_prob(logit_p, log_sigma, mu, target)  # [B, T]
     if masks is not None:
-        nll = nll * (1.0 - masks.float())
+        nll = nll * (~masks).float()
     return nll

--- a/modules/mdn/mdn.py
+++ b/modules/mdn/mdn.py
@@ -22,6 +22,13 @@ _LOG_2PI = math.log(2.0 * math.pi)
 
 
 def logsumexp(x, dim=-1, keepdim=True):
+    """Numerically stable log-sum-exp over `dim`.
+
+    :param x: input tensor.
+    :param dim: reduction dimension.
+    :param keepdim: whether to keep the reduced dimension.
+    :return: log(sum(exp(x), dim)) with the same keepdim semantics.
+    """
     m, _ = x.max(dim=dim, keepdim=True)
     m = torch.clamp(m, min=-1e30)
     out = m + torch.log(torch.exp(x - m).sum(dim=dim, keepdim=True))
@@ -29,6 +36,12 @@ def logsumexp(x, dim=-1, keepdim=True):
 
 
 def log_softmax(x, dim=-1):
+    """Log-softmax via logsumexp subtraction.
+
+    :param x: input logits.
+    :param dim: class dimension.
+    :return: log-softmax values with the same shape as x.
+    """
     return x - logsumexp(x, dim=dim, keepdim=True)
 
 
@@ -64,6 +77,13 @@ class MDNLayer(nn.Module):
             b[2 * n:] = torch.linspace(-0.5, 0.5, n)  # mu spread
 
     def forward(self, x):
+        """Map input features to bounded GMM parameters.
+
+        :param x: [B, T, F] backbone features.
+        :return: tuple (logit_p, log_sigma, mu), each [B, T, G], with
+            logit_p clamped at log_p_min and mu clamped to [log_scale_min,
+            log_scale_max] so the linear-domain duration cannot diverge.
+        """
         z = self.act(self.hidden(x))
         logit_p, log_sigma, mu = self.out(z).chunk(3, dim=-1)
         logit_p = torch.clamp(logit_p, min=self.log_p_min)
@@ -72,9 +92,19 @@ class MDNLayer(nn.Module):
 
     # -- distribution utils --------------------------------------------------
     def log_pi(self, logit_p):
+        """Log mixture weights from component logits.
+
+        :param logit_p: [B, T, G] component logits.
+        :return: log-softmax weights [B, T, G].
+        """
         return log_softmax(logit_p, dim=-1)
 
     def sigma(self, log_sigma):
+        """Standard deviation with configured lower clamp and floor.
+
+        :param log_sigma: [B, T, G] log-std values.
+        :return: positive sigma [B, T, G].
+        """
         ls = torch.clamp(log_sigma, min=self.log_sigma_min)
         return torch.exp(ls) + self.sigma_floor
 

--- a/modules/mdn/mdn.py
+++ b/modules/mdn/mdn.py
@@ -1,0 +1,108 @@
+"""
+MDN (Mixture Density Network) for DiffSinger duration prediction.
+
+Replaces the single-Gaussian regression head of the FastSpeech2 duration
+predictor with a Gaussian mixture. Training minimizes NLL (negative
+log-likelihood) of the ground-truth log-duration; at inference the mean of the
+most probable component is returned deterministically, so the ONNX duration
+interface (`dur.onnx`: {encoder_out, x_masks, ph_midi} -> {ph_dur_pred})
+remains unchanged (still a single scalar per phoneme).
+
+Numerical conventions follow
+https://github.com/nnsvs/nnsvs/blob/master/nnsvs/mdn.py
+(log-domain GMM, clamped log-sigma/log-pi, logsumexp NLL).
+"""
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+_LOG_2PI = math.log(2.0 * math.pi)
+
+
+def logsumexp(x, dim=-1, keepdim=True):
+    m, _ = x.max(dim=dim, keepdim=True)
+    m = torch.clamp(m, min=-1e30)
+    out = m + torch.log(torch.exp(x - m).sum(dim=dim, keepdim=True))
+    return out if keepdim else out.squeeze(dim)
+
+
+def log_softmax(x, dim=-1):
+    return x - logsumexp(x, dim=dim, keepdim=True)
+
+
+class MDNLayer(nn.Module):
+    """Gaussian-mixture output head.
+
+    x: (B, T, F)  ->  (log_pi, log_sigma, mu) each of shape (B, T, G).
+    """
+
+    def __init__(self, in_features, num_gaussians=8,
+                 log_p_min=-7.0, log_sigma_min=-7.0, sigma_floor=1e-6,
+                 log_scale_max=3.0, log_scale_min=-1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.num_gaussians = num_gaussians
+        self.log_p_min = log_p_min
+        self.log_sigma_min = log_sigma_min
+        self.sigma_floor = sigma_floor
+        self.log_scale_max = log_scale_max
+        self.log_scale_min = log_scale_min
+
+        self.hidden = nn.Linear(in_features, in_features)
+        self.act = nn.Tanh()
+        self.out = nn.Linear(in_features, 3 * num_gaussians)
+
+        nn.init.zeros_(self.out.bias)
+        nn.init.normal_(self.out.weight, std=0.02)
+        with torch.no_grad():
+            n = num_gaussians
+            b = self.out.bias
+            b[:n] = 0.0                 # pi logits: uniform baseline
+            b[n:2 * n] = 0.0            # log-sigma -> sigma ~ exp(0) = 1.0
+            b[2 * n:] = torch.linspace(-0.5, 0.5, n)  # mu spread
+
+    def forward(self, x):
+        z = self.act(self.hidden(x))
+        logit_p, log_sigma, mu = self.out(z).chunk(3, dim=-1)
+        logit_p = torch.clamp(logit_p, min=self.log_p_min)
+        mu = torch.clamp(mu, min=self.log_scale_min, max=self.log_scale_max)
+        return logit_p, log_sigma, mu
+
+    # -- distribution utils --------------------------------------------------
+    def log_pi(self, logit_p):
+        return log_softmax(logit_p, dim=-1)
+
+    def sigma(self, log_sigma):
+        ls = torch.clamp(log_sigma, min=self.log_sigma_min)
+        return torch.exp(ls) + self.sigma_floor
+
+    def log_prob(self, logit_p, log_sigma, mu, target):
+        """log p(target) under the mixture. target: [B, T], return [B, T]."""
+        lp = self.log_pi(logit_p)                  # [B, T, G]
+        s = self.sigma(log_sigma)                  # [B, T, G]
+        t = target.unsqueeze(-1)                   # [B, T, 1]
+        log_n = (-0.5 * (torch.log(s * s) + _LOG_2PI)
+                 - (t - mu) ** 2 / (2 * s * s))    # [B, T, G]
+        return logsumexp(log_n + lp, dim=-1)       # [B, T]
+
+    def point_estimate(self, logit_p, log_sigma, mu):
+        """Deterministic point: mean of most-probable component. [B, T]."""
+        p = F.softmax(logit_p, dim=-1)
+        idx = p.argmax(dim=-1, keepdim=True)       # [B, T, 1]
+        m = torch.gather(mu, dim=-1, index=idx).squeeze(-1)  # log-domain mu
+        return m
+
+
+def mdn_nll_loss(logit_p, log_sigma, mu, target, masks=None):
+    """Per-phoneme NLL (log domain). target: [B, T]; returns [B, T]."""
+    tgt = target.unsqueeze(-1)                     # [B, T, 1]
+    lp = log_softmax(logit_p)                      # [B, T, G]
+    s = torch.clamp(log_sigma, min=-7.0).exp() + 1e-6
+    log_n = (-0.5 * (torch.log(s * s) + _LOG_2PI)
+             - (tgt - mu) ** 2 / (2 * s * s))
+    nll = -(logsumexp(log_n + lp, dim=-1, keepdim=False))  # [B, T]
+    if masks is not None:
+        nll = nll * (1.0 - masks.float())
+    return nll

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -9,7 +9,6 @@ import utils.infer_utils
 from basics.base_dataset import BaseDataset
 from basics.base_task import BaseTask
 from modules.losses import DurationLoss, DiffusionLoss, RectifiedFlowLoss
-from modules.mdn.mdn import mdn_nll_loss
 from modules.metrics import (
     RawCurveAccuracy, RawCurveR2Score, RhythmCorrectness, PhonemeDurationAccuracy
 )
@@ -293,26 +292,12 @@ class VarianceTask(BaseTask):
             losses = {}
             if dur_pred is not None:
                 if hparams.get('use_mdn', False):
-                    # MDN is trained by NLL on the log-domain target. dur_pred is
-                    # only used as a point-estimate for evaluation (RhythmCorrectness).
-                    dp_module = self.model.fs2.dur_predictor
-                    log_dur_gt = torch.log(ph_dur.float() + hparams['dur_prediction_args']['log_offset'])
-                    # ph2word == 0 marks the leading padding token
-                    if ph2word is not None:
-                        non_pad = (ph2word != 0).float()
-                    else:
-                        non_pad = None
-                    nll = mdn_nll_loss(
-                        dp_module._mdn_logit_p,
-                        dp_module._mdn_log_sigma,
-                        dp_module._mdn_mu,
-                        log_dur_gt,
-                    )
-                    if non_pad is not None:
-                        nll = nll * non_pad
-                        losses['dur_loss'] = self.lambda_dur_loss * nll.sum() / (non_pad.sum() + 1e-8)
-                    else:
-                        losses['dur_loss'] = self.lambda_dur_loss * nll.mean()
+                    # DurationPredictor computes the masked per-phoneme NLL on
+                    # the log-domain target and returns it in the `sdp_loss`
+                    # slot (use_mdn and use_sdp are mutually exclusive).
+                    # The token padding mask (txt_tokens == PAD_INDEX) is
+                    # applied inside the predictor, so no ph2word mask here.
+                    losses['dur_loss'] = self.lambda_dur_loss * sdp_loss
                 else:
                     losses['dur_loss'] = self.lambda_dur_loss * self.dur_loss(dur_pred, ph_dur, ph2word=ph2word)
                 if hparams.get('use_sdp', False):

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -9,6 +9,7 @@ import utils.infer_utils
 from basics.base_dataset import BaseDataset
 from basics.base_task import BaseTask
 from modules.losses import DurationLoss, DiffusionLoss, RectifiedFlowLoss
+from modules.mdn.mdn import mdn_nll_loss
 from modules.metrics import (
     RawCurveAccuracy, RawCurveR2Score, RhythmCorrectness, PhonemeDurationAccuracy
 )
@@ -291,7 +292,29 @@ class VarianceTask(BaseTask):
         else:
             losses = {}
             if dur_pred is not None:
-                losses['dur_loss'] = self.lambda_dur_loss * self.dur_loss(dur_pred, ph_dur, ph2word=ph2word)
+                if hparams.get('use_mdn', False):
+                    # MDN is trained by NLL on the log-domain target. dur_pred is
+                    # only used as a point-estimate for evaluation (RhythmCorrectness).
+                    dp_module = self.model.fs2.dur_predictor
+                    log_dur_gt = torch.log(ph_dur.float() + hparams['dur_prediction_args']['log_offset'])
+                    # ph2word == 0 marks the leading padding token
+                    if ph2word is not None:
+                        non_pad = (ph2word != 0).float()
+                    else:
+                        non_pad = None
+                    nll = mdn_nll_loss(
+                        dp_module._mdn_logit_p,
+                        dp_module._mdn_log_sigma,
+                        dp_module._mdn_mu,
+                        log_dur_gt,
+                    )
+                    if non_pad is not None:
+                        nll = nll * non_pad
+                        losses['dur_loss'] = self.lambda_dur_loss * nll.sum() / (non_pad.sum() + 1e-8)
+                    else:
+                        losses['dur_loss'] = self.lambda_dur_loss * nll.mean()
+                else:
+                    losses['dur_loss'] = self.lambda_dur_loss * self.dur_loss(dur_pred, ph_dur, ph2word=ph2word)
                 if hparams.get('use_sdp', False):
                     losses['sdp_flow_loss'] = self.sdp_flow_loss(sdp_loss) * self.lambda_sdp_loss
                     lambda_sdp_reg_base = hparams.get('lambda_sdp_reg_loss', 0.1)


### PR DESCRIPTION
# PR: MDNv2 时长预测器（GMM 头 + NLL 损失）

> 目标仓库：`KakaruHayate/DiffSinger`（fork of openvpi/DiffSinger）
> 分支：`feat/mdn-duration-predictor`（基于 `integration-dual-timestep-stack`）
> 提交：`443a6b4 feat: MDNv2 duration predictor (GMM head + NLL loss)`

---

## 1. 动机

DiffSinger 现用 FastSpeech2 风格 `DurationPredictor`（单高斯 log-MSE 回归）。
实测歌声数据集（`ZH_hanser_dataset_fix`，1063 条 / 77 音素）显示：
元音/复韵母/鼻韵母时长 std 达 0.14–0.28s（≈甚至超过均值），max 2.4–2.7s，
长尾多峰严重；而辅音 std 仅 0.02–0.03s。单高斯回归只能给出条件均值，
对多峰分布会把极值拉向均值——短音拉长、长音削平。

NNSVS（`nnsvs/mdn.py`）用 **MDN（混合密度网络）+ log 域 NLL** 训练时长/切分
模型，社区验证对时长方差大的歌声数据有效。本 PR 将其移植进 DiffSinger
variance 链路。

## 2. 设计要点

- **训练**：预测头输出 GMM 参数 `(log_pi, log_sigma, mu)`，每个条件状态
  可聚多个峰（长短元音各占一个分量）；损失为 log 域 `ph_dur` 的 NLL
  （logsumexp 稳定实现，clamp `log_pi/log_sigma ≥ -7`，与 NNSVS 数值约定一致）。
- **推理**：确定性取**最大权重分量的均值**（`point_estimate`）→ 仍是
  每音素一个标量，**一次前向、无采样迭代**。
- **ONNX 兼容**：`dur.onnx` 接口 `{encoder_out, x_masks, ph_midi} -> {ph_dur_pred}`
  完全不变——不新增输入/输出，OpenUtau 前端无需改动。
- **与 SDP 互斥**：`use_mdn` 与 `use_sdp` 二选一（assert 保护）。

## 3. 改动文件（7 个，+207/-6）

| 文件 | 改动 |
|---|---|
| `modules/mdn/mdn.py`（新增） | `MDNLayer`（隐层 Tanh + 3G 输出头）、`mdn_nll_loss`、`point_estimate` |
| `modules/fastspeech/tts_modules.py` | `DurationPredictor` 增加 `use_mdn`/`mdn_args`；MDN 分支替代 `linear` 头；`_mdn_*` 记录原始分布参数供 loss 使用 |
| `modules/fastspeech/variance_encoder.py` | 从 `hparams` 透传 `use_mdn`/`mdn_args` |
| `training/variance_task.py` | `use_mdn=true` 时用 NLL 替代 `dur_loss`；按 `ph2word != 0` 掩码归一化 |
| `configs/variance.yaml` | `use_mdn: false` + `mdn_args` 默认值 |
| `configs/templates/config_variance.yaml` | 同上 |
| `configs/templates/config_duration.yaml` | 同上（含说明注释） |

## 4. 使用方式

```yaml
# configs/variance.yaml
use_mdn: true
mdn_args:
  num_gaussians: 8      # 高斯分量数（长尾多峰场景可试 16）
  log_p_min: -7.0
  log_sigma_min: -7.0
  log_scale_max: 3.0    # log 时长上限 ≈ e^3 = 20s
  log_scale_min: -1.0   # log 时长下限 ≈ e^-1 ≈ 0.37s
  sigma_floor: 0.000001 # 数值稳定下限（注意 YAML 需写浮点字面量）
```

训练/导出流程与基线完全一致（`train.py` / `export` 脚本无需改动）。

## 5. 验证结果

| 验证项 | 结果 |
|---|---|
| MDN 数学（单簇拟合收敛） | NLL 单调下降，点估计收敛到目标时长 ±0.03s |
| `DurationPredictor` 训练 forward（infer=False） | 输出 `(B,T)` 点估计，`_mdn_*` 参数形状 `(B,T,G)` 正确 |
| NLL 反向传播 | 全部参数梯度存在，无 NaN |
| 推理 forward（infer=True） | 输出非负、形状 `(B,T)` |
| **ONNX 导出**（TorchScript exporter，`dynamo=False`，opset 17） | 输入 `{encoder_out, x_masks, ph_midi}`，输出 `{ph_dur_pred}`，动态 `n_tokens` 轴完整 |
| **onnxruntime 一致性** | torch vs ONNX Runtime 最大偏差 **1.2e-7** |

关键点：真实部署链路 `forward_dur_predictor`（`dur_cond = encoder_out + midi_embed(ph_midi)`，
`infer=True` 默认）已在导出测试中完整复刻，`ph_midi` 输入被真正使用（非被裁剪）。

## 6. 已知限制与下一步

- 当前为**纯 NLL**，未加 MSE 辅助项；如需更稳的短音端，可加 `add_mse_loss`
  辅助回归（本 PR 未实现，留作后续）。
- 未进行真实数据训练对比——建议在 `ZH_hanser_dataset_fix` 上做
  **DP(log-MSE) vs MDN(NLL)** 消融：同一 backbone、同一步数，
  对比 dur 相关指标（与 `modules/metrics/duration.py` 对齐）。
- `use_mdn` 与 `use_sdp` 互斥，两者不可叠加。

## 7. 参考

- NNSVS MDN 实现：https://github.com/nnsvs/nnsvs/blob/master/nnsvs/mdn.py
- DiffSinger 现行时长链路：`modules/fastspeech/variance_encoder.py`、
  `deployment/exporters/variance_exporter.py`（`view_as_dur_predictor`）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Mixture Density Network (MDN) duration prediction.
  * Added configurable Gaussian components, probability and scale bounds, and sigma flooring.
  * Added padding-aware MDN training using negative log-likelihood loss.
  * Added deterministic duration inference using the most probable Gaussian component.
* **Compatibility**
  * MDN remains disabled by default, preserving existing behavior and interfaces.
  * MDN and stochastic duration prediction modes cannot be enabled together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->