### PR TITLE
feat(mixln): add config switch to disable speaker-shuffle during training

### DIFF
--- a/configs/acoustic.yaml
+++ b/configs/acoustic.yaml
@@ -57,6 +57,8 @@ use_spk_id: false
 num_spk: 1
 use_mix_ln: false
 mix_ln_layer: [0, 2]
+# If true, Mixed_LayerNorm shuffles/mixes speakers within a batch during training.
+mixln_shuffle_speakers: false
 use_energy_embed: false
 use_breathiness_embed: false
 use_voicing_embed: false

--- a/configs/templates/config_acoustic.yaml
+++ b/configs/templates/config_acoustic.yaml
@@ -45,6 +45,8 @@ num_spk: 1
 
 use_mix_ln: false
 mix_ln_layer: [0, 2]
+# If true, Mixed_LayerNorm shuffles/mixes speakers within a batch during training.
+mixln_shuffle_speakers: false
 
 # NOTICE: before enabling variance embeddings, please read the docs at
 # https://github.com/openvpi/DiffSinger/tree/main/docs/BestPractices.md#choosing-variance-parameters

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -296,11 +296,16 @@ class Mixed_LayerNorm(nn.Module):
             condition_channels: int,
             beta_distribution_concentration: float = 0.2,
             eps: float = 1e-5,
-            bias: bool = True
+            bias: bool = True,
+            *,
+            shuffle_speakers: bool = False
     ):
         super().__init__()
         self.channels = channels
         self.eps = eps
+        # If false, skip the speaker-shuffle mixture while keeping the
+        # conditional-affine structure (default).
+        self.shuffle_speakers = shuffle_speakers
 
         self.beta_distribution = torch.distributions.Beta(
             beta_distribution_concentration,
@@ -325,6 +330,8 @@ class Mixed_LayerNorm(nn.Module):
         betas, gammas = torch.split(affine_params, self.channels, dim=-1)
 
         if not self.training or x.size(0) == 1:
+            return gammas * x + betas
+        if not self.shuffle_speakers:
             return gammas * x + betas
 
         shuffle_indices = torch.randperm(x.size(0), device=x.device)
@@ -463,7 +470,8 @@ class LaurelBlock(nn.Module):
 class EncSALayer(nn.Module):
     def __init__(self, c, num_heads, dropout, attention_dropout=0.1,
                  relu_dropout=0.1, kernel_size=9, act='gelu', rotary_embed=None,
-                 layer_idx=None, mix_ln_layer=None, use_laurel_block=False
+                 layer_idx=None, mix_ln_layer=None, use_laurel_block=False,
+                 mixln_shuffle_speakers=False
                  ):
         super().__init__()
         self.dropout = dropout
@@ -473,7 +481,7 @@ class EncSALayer(nn.Module):
                 and layer_idx in mix_ln_layer
         )
         if self.use_mix_ln:
-            self.layer_norm1 = Mixed_LayerNorm(c, c)
+            self.layer_norm1 = Mixed_LayerNorm(c, c, shuffle_speakers=mixln_shuffle_speakers)
         else:
             self.layer_norm1 = LayerNorm(c)
         # Always use the in-house manual attention. With rotary_embed=None this
@@ -486,7 +494,7 @@ class EncSALayer(nn.Module):
             c, num_heads, dropout=attention_dropout, bias=False, rotary_embed=rotary_embed
         )
         if self.use_mix_ln:
-            self.layer_norm2 = Mixed_LayerNorm(c, c)
+            self.layer_norm2 = Mixed_LayerNorm(c, c, shuffle_speakers=mixln_shuffle_speakers)
         else:
             self.layer_norm2 = LayerNorm(c)
         self.ffn = TransformerFFNLayer(

--- a/modules/fastspeech/acoustic_encoder.py
+++ b/modules/fastspeech/acoustic_encoder.py
@@ -60,6 +60,7 @@ class FastSpeech2Acoustic(nn.Module):
             use_rope=hparams.get('use_rope', False), rope_interleaved=hparams.get('rope_interleaved', True),
             mix_ln_layer=self.mix_ln_layer, rope_theta=hparams.get('rope_theta', 10000),
             use_laurel_block=hparams.get('use_laurel_block', False),
+            mixln_shuffle_speakers=hparams.get('mixln_shuffle_speakers', False),
         )
 
         self.pitch_embed = AdamWLinear(1, hparams['hidden_size'])

--- a/modules/fastspeech/tts_modules.py
+++ b/modules/fastspeech/tts_modules.py
@@ -15,7 +15,7 @@ DEFAULT_MAX_TARGET_POSITIONS = 2000
 
 class TransformerEncoderLayer(nn.Module):
     def __init__(self, hidden_size, dropout, kernel_size=None, act='gelu', num_heads=2, rotary_embed=None,
-                 layer_idx=None, mix_ln_layer=None, use_laurel_block=False):
+                 layer_idx=None, mix_ln_layer=None, use_laurel_block=False, mixln_shuffle_speakers=False):
         super().__init__()
         self.op = EncSALayer(
             hidden_size, num_heads, dropout=dropout,
@@ -23,7 +23,8 @@ class TransformerEncoderLayer(nn.Module):
             kernel_size=kernel_size,
             act=act, rotary_embed=rotary_embed,
             layer_idx=layer_idx, mix_ln_layer=mix_ln_layer,
-            use_laurel_block=use_laurel_block
+            use_laurel_block=use_laurel_block,
+            mixln_shuffle_speakers=mixln_shuffle_speakers
         )
 
     def forward(self, x, **kwargs):
@@ -491,7 +492,7 @@ class FastSpeech2Encoder(nn.Module):
             ffn_kernel_size=9, ffn_act='gelu',
             dropout=None, num_heads=2, use_pos_embed=True, rel_pos=True,
             use_rope=False, rope_interleaved=True, mix_ln_layer=None, rope_theta=10000,
-            use_laurel_block=False
+            use_laurel_block=False, mixln_shuffle_speakers=False
     ):
         super().__init__()
         self.num_layers = num_layers
@@ -514,7 +515,8 @@ class FastSpeech2Encoder(nn.Module):
                 self.hidden_size, self.dropout,
                 kernel_size=ffn_kernel_size, act=ffn_act,
                 num_heads=num_heads, rotary_embed=rotary_embed,
-                layer_idx=i, mix_ln_layer=mix_ln_layer, use_laurel_block=use_laurel_block
+                layer_idx=i, mix_ln_layer=mix_ln_layer, use_laurel_block=use_laurel_block,
+                mixln_shuffle_speakers=mixln_shuffle_speakers
             )
             for i in range(self.num_layers)
         ])


### PR DESCRIPTION
## 概要

为 Mixed_LayerNorm 添加 \mixln_shuffle_speakers\ 配置开关：关闭（默认）时训练保留条件仿射 LN 网络结构，但不再对 batch 内说话人做随机洗牌 + Beta 混合，使每个 SPK 的 affine 参数在一步内保持一致，减少跨说话人表征串扰（inter-speaker leakage）。

## 改动

- \modules/commons/common_layers.py\：\Mixed_LayerNorm\ 新增 \shuffle_speakers\ 构造参数（默认 False），训练阶段改由此参数控制是否执行 speaker shuffle + Beta mixture；\EncSALayer\ 透传 \mixln_shuffle_speakers\。
- \modules/fastspeech/tts_modules.py\：\TransformerEncoderLayer\ / \FastSpeech2Encoder\ 逐层透传开关（默认 False）。
- \modules/fastspeech/acoustic_encoder.py\：在允许读取 hparams 的入口处读取 \mixln_shuffle_speakers\（默认 False）并传入 encoder。
- \configs/acoustic.yaml\ / \configs/templates/config_acoustic.yaml\：同步新增 \mixln_shuffle_speakers: false\。

## 兼容性

- 未显式设置该键的旧配置按新默认（False=不洗牌）运行；需要恢复原洗牌行为只需设 \mixln_shuffle_speakers: true\。
- 参数遵循仓库规范：**不在未 import hparams 的模块引入 hparams 引用**，开关全部经构造函数逐层透传。

## 已验证

- 关闭时训练模式确定性（同 seed 输出相同）；开启时保持随机混合。
- eval 模式结构与原实现一致。
- hparams=off 时 4 个 Mixed_LayerNorm（layer 0/2 × norm1/norm2）均收到 \shuffle_speakers=False\。

## 动机

Yousa 等多 SPK 声库在共享模型重训后出现单 SPK 音色/稳定性劣化的调查中，怀疑训练期 speaker-shuffle 混合把同 batch 内其他 SPK（如 hanser/Liliko）的 affine 统计渗入该 SPK 的门控 LN。此开关用于消融验证。