### PR TITLE
feat: low-memory Forward XM (best-of-K) for pitch/variance Rectified Flow

### DIFF
--- a/configs/acoustic.yaml
+++ b/configs/acoustic.yaml
@@ -96,6 +96,12 @@ main_loss_type: l2
 main_loss_log_norm: false
 schedule_type: 'linear'
 
+# Explorative Modeling for full-depth Rectified Flow training.
+# K=1 preserves the standard training objective. Larger K trades additional
+# no-gradient forward passes for candidate exploration without K-fold VRAM.
+xm_best_of_k: 1
+xm_chunk_size: 1
+
 # shallow diffusion
 use_shallow_diffusion: true
 T_start: 0.4

--- a/configs/templates/config_acoustic.yaml
+++ b/configs/templates/config_acoustic.yaml
@@ -110,6 +110,11 @@ shallow_diffusion_args:
   aux_decoder_grad: 0.1
 lambda_aux_mel_loss: 0.2
 
+# Explorative Modeling is currently available for full-depth Rectified Flow.
+# Set use_shallow_diffusion=false before raising xm_best_of_k above 1.
+xm_best_of_k: 1
+xm_chunk_size: 1
+
 optimizer_args:
   optimizer_cls: modules.optimizer.muon.Muon_AdamW
   lr: 0.0006

--- a/configs/templates/config_variance.yaml
+++ b/configs/templates/config_variance.yaml
@@ -125,6 +125,12 @@ lambda_dur_loss: 1.0
 lambda_pitch_loss: 1.0
 lambda_var_loss: 1.0
 
+# Low-memory Forward XM is available for Rectified Flow pitch/variance
+# predictors. Enable either predictor independently by raising its K above 1.
+xm_pitch_best_of_k: 1
+xm_variance_best_of_k: 1
+xm_chunk_size: 1
+
 optimizer_args:
   optimizer_cls: modules.optimizer.muon.Muon_AdamW
   lr: 0.0006

--- a/configs/variance.yaml
+++ b/configs/variance.yaml
@@ -130,6 +130,13 @@ timesteps: 1000
 max_beta: 0.02
 main_loss_type: l2
 main_loss_log_norm: true
+
+# Low-memory Forward XM for Rectified Flow predictors. K=1 preserves the
+# standard objective. Pitch and variance exploration can be enabled separately.
+xm_pitch_best_of_k: 1
+xm_variance_best_of_k: 1
+xm_chunk_size: 1
+
 sampling_algorithm: euler
 sampling_steps: 20
 diff_accelerator: ddim

--- a/modules/core/reflow.py
+++ b/modules/core/reflow.py
@@ -34,54 +34,85 @@ class RectifiedFlow(nn.Module):
         self.register_buffer('spec_min', spec_min, persistent=False)
         self.register_buffer('spec_max', spec_max, persistent=False)
 
-    def prepare_training_inputs(self, gt_spec, t=None, noise=None):
-        """Normalize a ground-truth target and (optionally) an external noise sample.
+    def _sample_train_timesteps(self, batch_size, num_frames, device):
+        """Sample one (or a dual pair of) timesteps plus a per-frame mask.
 
-        :return: ``(spec, t, noise)`` where ``spec`` is the normalized target in the
-            shape the denoiser expects (``[B, F, M, T]``), ``t`` is one timestep per
-            batch element, and ``noise`` is the start-of-flow noise used for the
-            Rectified Flow interpolation. When ``t``/``noise`` are omitted they are
-            sampled here so Explorative Modeling can replay an identical candidate
-            (same noise) with gradients after a no-gradient exploration pass.
+        Mirrors the sampling distribution used by ``forward`` so that
+        Explorative Modeling explores the exact same objective as the baseline:
+        ``t1`` lives in ``[T_start, 1]`` (shallow diffusion start) and, when
+        ``use_dual_timestep``, a second ``t2`` and a per-frame 25%-density mask
+        are sampled.
+        """
+        t1 = self.t_start + (1.0 - self.t_start) * torch.rand((batch_size, 1), device=device)
+        if self.use_dual_timestep:
+            t2 = self.t_start + (1.0 - self.t_start) * torch.rand((batch_size, 1), device=device)
+            mask = (torch.rand(batch_size, num_frames, device=device) < 0.25).float()
+        else:
+            t2 = None
+            mask = None
+        return t1, t2, mask
+
+    def prepare_training_inputs(
+            self, gt_spec, t1=None, t2=None, mask=None, noise=None,
+            num_frames=None
+    ):
+        """Normalize a ground-truth target and (optionally) timestep/noise.
+
+        :return: ``(spec, t1, t2, mask, noise)`` where ``spec`` is the
+            normalized target in the shape the denoiser expects (``[B, F, M, T]``).
+            Timesteps/``mask`` are supplied by the caller when known (Explorative
+            Modeling samplesthem once and replays the winner) and sampled here
+            otherwise using the same distribution as ``forward``. ``noise`` is the
+            start-of-flow noise used for the interpolation.
         """
         spec = self.norm_spec(gt_spec).transpose(-2, -1)
         if self.num_feats == 1:
             spec = spec[:, None, :, :]
         batch_size = spec.shape[0]
-        if t is None:
-            t = self.t_start + (1.0 - self.t_start) * torch.rand(
-                (batch_size,), device=spec.device
-            )
+        num_frames = spec.shape[-1] if num_frames is None else num_frames
+        device = spec.device
+        if t1 is None:
+            t1, t2, mask = self._sample_train_timesteps(batch_size, num_frames, device)
         else:
-            t = t.to(spec)
+            t1 = t1.to(spec)
+            if t2 is not None:
+                t2 = t2.to(spec)
+            if mask is not None:
+                mask = mask.to(spec)
         if noise is None:
             noise = torch.randn_like(spec)
         else:
             noise = noise.to(spec)
-        return spec, t, noise
+        return spec, t1, t2, mask, noise
 
     def p_losses(self, x_end, t1, cond, t2=None, mask=None, noise=None):
         t = t1 if mask is None else t1 + (t2 - t1) * mask
         x_start = torch.randn_like(x_end) if noise is None else noise
-        batch_size = x_end.shape[0]
-        x_t = x_start + t.reshape(batch_size, 1, 1, 1) * (x_end - x_start)
+        # ``t`` is [B, 1] (single step) or [B, T] (dual, per-frame); the
+        # ``[:, None, None, :]`` index broadcasts t over the channel/bins dims.
+        x_t = x_start + t[:, None, None, :] * (x_end - x_start)
         s1 = t1 * self.time_scale_factor
         s2 = None if t2 is None else t2 * self.time_scale_factor
         v_pred = self.velocity_fn(x_t, s1, cond, s2, mask)
 
         return v_pred, x_end - x_start, t
 
-    def training_forward(self, condition, gt_spec, t=None, noise=None):
-        """Training entry point that keeps the flow noise boundary explicit.
+    def training_forward(
+            self, condition, gt_spec, t1=None, t2=None, mask=None, noise=None
+    ):
+        """Training entry point that keeps timestep/noise boundaries explicit.
 
         Explorative Modeling uses this to evaluate many candidate noises without
-        gradients and then replay the winning candidate (same ``t``/``noise``) with
-        gradients so upstream condition encoders remain trainable. Falls back to the
-        standard single-flow objective when ``noise`` is ``None``.
+        gradients and then replay the winning candidate (same timesteps + noise)
+        with gradients so upstream condition encoders remain trainable. When the
+        timesteps/``noise`` are omitted, the standard single-flow objective is
+        produced (identical distribution to ``forward``).
         """
         cond = condition.transpose(1, 2)
-        spec, t, noise = self.prepare_training_inputs(gt_spec, t=t, noise=noise)
-        v_pred, v_gt, t = self.p_losses(spec, t, cond=cond, noise=noise)
+        spec, t1, t2, mask, noise = self.prepare_training_inputs(
+            gt_spec, t1=t1, t2=t2, mask=mask, noise=noise
+        )
+        v_pred, v_gt, t = self.p_losses(spec, t1, cond=cond, t2=t2, mask=mask, noise=noise)
         return v_pred, v_gt, t
 
     def forward(self, condition, gt_spec=None, src_spec=None, infer=True):
@@ -90,19 +121,7 @@ class RectifiedFlow(nn.Module):
         device = condition.device
 
         if not infer:
-            # gt_spec: [B, T, M] or [B, F, T, M]
-            spec = self.norm_spec(gt_spec).transpose(-2, -1)  # [B, M, T] or [B, F, M, T]
-            if self.num_feats == 1:
-                spec = spec[:, None, :, :]  # [B, F=1, M, T]
-            t1 = self.t_start + (1.0 - self.t_start) * torch.rand((b, 1), device=device)
-            if self.use_dual_timestep:
-                t2 = self.t_start + (1.0 - self.t_start) * torch.rand((b, 1), device=device)
-                mask = (torch.rand(b, n_frames, device=device) < 0.25).float()
-            else:
-                t2 = None
-                mask = None
-            v_pred, v_gt, t = self.p_losses(spec, t1, cond=cond, t2=t2, mask=mask)
-            return v_pred, v_gt, t
+            return self.training_forward(condition, gt_spec)
         else:
             # src_spec: [B, T, M] or [B, F, T, M]
             if src_spec is not None:

--- a/modules/core/reflow.py
+++ b/modules/core/reflow.py
@@ -34,15 +34,55 @@ class RectifiedFlow(nn.Module):
         self.register_buffer('spec_min', spec_min, persistent=False)
         self.register_buffer('spec_max', spec_max, persistent=False)
 
-    def p_losses(self, x_end, t1, cond, t2=None, mask=None):
+    def prepare_training_inputs(self, gt_spec, t=None, noise=None):
+        """Normalize a ground-truth target and (optionally) an external noise sample.
+
+        :return: ``(spec, t, noise)`` where ``spec`` is the normalized target in the
+            shape the denoiser expects (``[B, F, M, T]``), ``t`` is one timestep per
+            batch element, and ``noise`` is the start-of-flow noise used for the
+            Rectified Flow interpolation. When ``t``/``noise`` are omitted they are
+            sampled here so Explorative Modeling can replay an identical candidate
+            (same noise) with gradients after a no-gradient exploration pass.
+        """
+        spec = self.norm_spec(gt_spec).transpose(-2, -1)
+        if self.num_feats == 1:
+            spec = spec[:, None, :, :]
+        batch_size = spec.shape[0]
+        if t is None:
+            t = self.t_start + (1.0 - self.t_start) * torch.rand(
+                (batch_size,), device=spec.device
+            )
+        else:
+            t = t.to(spec)
+        if noise is None:
+            noise = torch.randn_like(spec)
+        else:
+            noise = noise.to(spec)
+        return spec, t, noise
+
+    def p_losses(self, x_end, t1, cond, t2=None, mask=None, noise=None):
         t = t1 if mask is None else t1 + (t2 - t1) * mask
-        x_start = torch.randn_like(x_end)
-        x_t = x_start + t[:, None, None,:] * (x_end - x_start)
+        x_start = torch.randn_like(x_end) if noise is None else noise
+        batch_size = x_end.shape[0]
+        x_t = x_start + t.reshape(batch_size, 1, 1, 1) * (x_end - x_start)
         s1 = t1 * self.time_scale_factor
         s2 = None if t2 is None else t2 * self.time_scale_factor
         v_pred = self.velocity_fn(x_t, s1, cond, s2, mask)
 
         return v_pred, x_end - x_start, t
+
+    def training_forward(self, condition, gt_spec, t=None, noise=None):
+        """Training entry point that keeps the flow noise boundary explicit.
+
+        Explorative Modeling uses this to evaluate many candidate noises without
+        gradients and then replay the winning candidate (same ``t``/``noise``) with
+        gradients so upstream condition encoders remain trainable. Falls back to the
+        standard single-flow objective when ``noise`` is ``None``.
+        """
+        cond = condition.transpose(1, 2)
+        spec, t, noise = self.prepare_training_inputs(gt_spec, t=t, noise=noise)
+        v_pred, v_gt, t = self.p_losses(spec, t, cond=cond, noise=noise)
+        return v_pred, v_gt, t
 
     def forward(self, condition, gt_spec=None, src_spec=None, infer=True):
         cond = condition.transpose(1, 2)
@@ -246,7 +286,6 @@ class MultiVarianceRectifiedFlow(RepetitiveRectifiedFlow):
 
     def norm_spec(self, xs: list | tuple):
         """
-
         :param xs: sequence of [B, T]
         :return: [B, F, T] => super().norm_spec(xs) => [B, F, T, R]
         """
@@ -259,7 +298,6 @@ class MultiVarianceRectifiedFlow(RepetitiveRectifiedFlow):
 
     def denorm_spec(self, xs):
         """
-
         :param xs: [B, T, R] or [B, F, T, R] => super().denorm_spec(xs) => [B, T] or [B, F, T]
         :return: sequence of [B, T]
         """
@@ -270,4 +308,3 @@ class MultiVarianceRectifiedFlow(RepetitiveRectifiedFlow):
             xs = xs.unbind(dim=1)
         assert len(xs) == self.num_feats
         return self.clamp_spec(xs)
-

--- a/modules/core/xm.py
+++ b/modules/core/xm.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+from torch import Tensor, nn
+
+
+def _repeat_batch(value, repeats: int):
+    if isinstance(value, tuple):
+        return tuple(torch.cat([item] * repeats, dim=0) for item in value)
+    if isinstance(value, list):
+        return [torch.cat([item] * repeats, dim=0) for item in value]
+    return torch.cat([value] * repeats, dim=0)
+
+
+def run_reflow_xm(
+        predictor: nn.Module,
+        condition: Tensor,
+        target: Tensor | Sequence[Tensor],
+        loss_fn: nn.Module,
+        non_padding: Tensor | None,
+        best_of_k: int,
+        chunk_size: int,
+):
+    """Run low-memory Forward XM for a Rectified Flow predictor.
+
+    Candidate noises are evaluated without gradients in bounded chunks. All
+    candidates for an original sample share one timestep. The winning noise is
+    replayed once with gradients so upstream condition encoders remain trainable.
+    """
+    if best_of_k < 2:
+        raise ValueError('run_reflow_xm requires best_of_k >= 2.')
+    if chunk_size < 1:
+        raise ValueError('XM chunk_size must be at least 1.')
+
+    spec, timestep, _ = predictor.prepare_training_inputs(target)
+    batch_size = spec.shape[0]
+    best_losses = torch.full((batch_size,), float('inf'), device=spec.device)
+    best_noise = torch.empty_like(spec)
+
+    dropout_modules = [
+        module for module in predictor.modules()
+        if isinstance(module, nn.Dropout) and module.p > 0.
+    ]
+    if dropout_modules:
+        raise RuntimeError(
+            'Explorative Modeling save-memory replay requires predictor backbone dropout_rate=0.'
+        )
+
+    with torch.no_grad():
+        for chunk_start in range(0, best_of_k, chunk_size):
+            chunk_candidates = min(chunk_size, best_of_k - chunk_start)
+            noise = torch.randn(
+                (chunk_candidates, *spec.shape),
+                device=spec.device,
+                dtype=spec.dtype,
+            )
+            chunk_condition = torch.cat([condition.detach()] * chunk_candidates, dim=0)
+            chunk_target = _repeat_batch(target, chunk_candidates)
+            chunk_timestep = torch.cat([timestep] * chunk_candidates, dim=0)
+            chunk_non_padding = None if non_padding is None else torch.cat(
+                [non_padding] * chunk_candidates, dim=0
+            )
+
+            v_pred, v_gt, _ = predictor.training_forward(
+                chunk_condition,
+                chunk_target,
+                t=chunk_timestep,
+                noise=noise.flatten(0, 1),
+            )
+            chunk_losses = loss_fn(
+                v_pred,
+                v_gt,
+                t=chunk_timestep,
+                non_padding=chunk_non_padding,
+                reduction='none',
+            ).reshape(chunk_candidates, batch_size)
+            chunk_best_losses, chunk_best_indices = chunk_losses.min(dim=0)
+            batch_indices = torch.arange(batch_size, device=spec.device)
+            chunk_best_noise = noise[chunk_best_indices, batch_indices]
+            replace = chunk_best_losses < best_losses
+            best_losses[replace] = chunk_best_losses[replace]
+            best_noise[replace] = chunk_best_noise[replace]
+
+    if hasattr(torch, 'clear_autocast_cache'):
+        torch.clear_autocast_cache()
+    return predictor.training_forward(
+        condition,
+        target,
+        t=timestep,
+        noise=best_noise,
+    )

--- a/modules/core/xm.py
+++ b/modules/core/xm.py
@@ -26,17 +26,28 @@ def run_reflow_xm(
     """Run low-memory Forward XM for a Rectified Flow predictor.
 
     Candidate noises are evaluated without gradients in bounded chunks. All
-    candidates for an original sample share one timestep. The winning noise is
-    replayed once with gradients so upstream condition encoders remain trainable.
+    candidates for an original sample share one timestep (it uses the same
+    sampling distribution as ``forward``, including ``T_start`` for shallow
+    diffusion and, when ``use_dual_timestep``, a shared ``t2/mask``). The
+    winning noise is replayed once with gradients so upstream condition
+    encoders remain trainable.
+
+    Invariants:
+    - Every batch element is always included in the replay (only noise
+      candidates are dropped) -> the backward data amount equals the baseline.
+    - The replayed trajectory uses exactly the winning noise and the same
+      timesteps, so the trained objective matches the explored one.
     """
     if best_of_k < 2:
         raise ValueError('run_reflow_xm requires best_of_k >= 2.')
     if chunk_size < 1:
         raise ValueError('XM chunk_size must be at least 1.')
 
-    spec, timestep, _ = predictor.prepare_training_inputs(target)
+    spec, t1, t2, mask, _ = predictor.prepare_training_inputs(target)
     batch_size = spec.shape[0]
-    best_losses = torch.full((batch_size,), float('inf'), device=spec.device)
+    device = spec.device
+    effective_t = t1 if mask is None else t1 + (t2 - t1) * mask
+    best_losses = torch.full((batch_size,), float('inf'), device=device)
     best_noise = torch.empty_like(spec)
 
     dropout_modules = [
@@ -53,12 +64,15 @@ def run_reflow_xm(
             chunk_candidates = min(chunk_size, best_of_k - chunk_start)
             noise = torch.randn(
                 (chunk_candidates, *spec.shape),
-                device=spec.device,
+                device=device,
                 dtype=spec.dtype,
             )
             chunk_condition = torch.cat([condition.detach()] * chunk_candidates, dim=0)
             chunk_target = _repeat_batch(target, chunk_candidates)
-            chunk_timestep = torch.cat([timestep] * chunk_candidates, dim=0)
+            chunk_t1 = torch.cat([t1] * chunk_candidates, dim=0)
+            chunk_t2 = None if t2 is None else torch.cat([t2] * chunk_candidates, dim=0)
+            chunk_mask = None if mask is None else torch.cat([mask] * chunk_candidates, dim=0)
+            chunk_effective_t = torch.cat([effective_t] * chunk_candidates, dim=0)
             chunk_non_padding = None if non_padding is None else torch.cat(
                 [non_padding] * chunk_candidates, dim=0
             )
@@ -66,18 +80,20 @@ def run_reflow_xm(
             v_pred, v_gt, _ = predictor.training_forward(
                 chunk_condition,
                 chunk_target,
-                t=chunk_timestep,
+                t1=chunk_t1,
+                t2=chunk_t2,
+                mask=chunk_mask,
                 noise=noise.flatten(0, 1),
             )
             chunk_losses = loss_fn(
                 v_pred,
                 v_gt,
-                t=chunk_timestep,
+                t=chunk_effective_t,
                 non_padding=chunk_non_padding,
                 reduction='none',
             ).reshape(chunk_candidates, batch_size)
             chunk_best_losses, chunk_best_indices = chunk_losses.min(dim=0)
-            batch_indices = torch.arange(batch_size, device=spec.device)
+            batch_indices = torch.arange(batch_size, device=device)
             chunk_best_noise = noise[chunk_best_indices, batch_indices]
             replace = chunk_best_losses < best_losses
             best_losses[replace] = chunk_best_losses[replace]
@@ -88,6 +104,8 @@ def run_reflow_xm(
     return predictor.training_forward(
         condition,
         target,
-        t=timestep,
+        t1=t1,
+        t2=t2,
+        mask=mask,
         noise=best_noise,
     )

--- a/modules/losses/reflow_loss.py
+++ b/modules/losses/reflow_loss.py
@@ -39,12 +39,28 @@ class RectifiedFlowLoss(nn.Module):
         else:
             return self.loss(v_pred, v_gt)
 
-    def forward(self, v_pred: Tensor, v_gt: Tensor, t: Tensor, non_padding: Tensor = None) -> Tensor:
+    def forward(
+            self, v_pred: Tensor, v_gt: Tensor, t: Tensor,
+            non_padding: Tensor = None, reduction: str = 'mean'
+    ) -> Tensor:
         """
         :param v_pred: [B, 1, M, T]
         :param v_gt: [B, 1, M, T]
         :param t: [B, 1] or [B, T]
         :param non_padding: [B, T, M]
+        :param reduction: ``mean`` for the original scalar objective, or
+            ``none`` for one valid-frame-normalized loss per batch element.
         """
         v_pred, v_gt = self._mask_non_padding(v_pred, v_gt, non_padding)
-        return self._forward(v_pred, v_gt, t=t).mean()
+        loss = self._forward(v_pred, v_gt, t=t)
+        if reduction == 'mean':
+            return loss.mean()
+        if reduction != 'none':
+            raise ValueError(f'Unsupported reduction: {reduction}.')
+        if non_padding is None:
+            return loss.flatten(start_dim=1).mean(dim=1)
+
+        mask = non_padding.transpose(1, 2).unsqueeze(1).to(loss)
+        valid_elements = mask.flatten(start_dim=1).sum(dim=1)
+        valid_elements *= loss.shape[1] * loss.shape[2]
+        return loss.flatten(start_dim=1).sum(dim=1) / valid_elements.clamp_min(1.)

--- a/modules/toplevel.py
+++ b/modules/toplevel.py
@@ -93,7 +93,8 @@ class DiffSingerAcoustic(CategorizedModule, ParameterAdaptorModule):
 
     def forward(
             self, txt_tokens, mel2ph, f0, key_shift=None, speed=None,
-            spk_embed_id=None, languages=None, gt_mel=None, infer=True, **kwargs
+            spk_embed_id=None, languages=None, gt_mel=None, infer=True,
+            diffusion_fn=None, **kwargs
     ) -> ShallowDiffusionOutput:
         condition = self.encode_condition(
             txt_tokens, mel2ph, f0, key_shift=key_shift, speed=speed,
@@ -114,21 +115,21 @@ class DiffSingerAcoustic(CategorizedModule, ParameterAdaptorModule):
             mel_pred *= ((mel2ph > 0).float()[:, :, None])
             return ShallowDiffusionOutput(aux_out=aux_mel_pred, diff_out=mel_pred)
         else:
+            diff_fn = diffusion_fn or (
+                lambda cond, gt: self.diffusion(cond, gt_spec=gt, infer=False)
+            )
             if self.use_shallow_diffusion:
                 if self.train_aux_decoder:
                     aux_cond = condition * self.aux_decoder_grad + condition.detach() * (1 - self.aux_decoder_grad)
                     aux_out = self.aux_decoder(aux_cond, infer=False)
                 else:
                     aux_out = None
-                if self.train_diffusion:
-                    diff_out = self.diffusion(condition, gt_spec=gt_mel, infer=False)
-                else:
-                    diff_out = None
+                diff_out = diff_fn(condition, gt_mel) if self.train_diffusion else None
                 return ShallowDiffusionOutput(aux_out=aux_out, diff_out=diff_out)
 
             else:
                 aux_out = None
-                diff_out = self.diffusion(condition, gt_spec=gt_mel, infer=False)
+                diff_out = diff_fn(condition, gt_mel)
                 return ShallowDiffusionOutput(aux_out=aux_out, diff_out=diff_out)
 
 

--- a/modules/toplevel.py
+++ b/modules/toplevel.py
@@ -245,7 +245,7 @@ class DiffSingerVariance(CategorizedModule, ParameterAdaptorModule):
             base_pitch=None, pitch=None, pitch_expr=None, pitch_retake=None,
             variance_retake: Dict[str, Tensor] = None,
             spk_id=None, languages=None,
-            infer=True, **kwargs
+            infer=True, pitch_predictor_fn=None, variance_predictor_fn=None, **kwargs
     ):
         if self.use_spk_id:
             ph_spk_mix_embed = kwargs.get('ph_spk_mix_embed')
@@ -343,7 +343,11 @@ class DiffSingerVariance(CategorizedModule, ParameterAdaptorModule):
             if infer:
                 pitch_pred_out = self.pitch_predictor(pitch_cond, infer=True)
             else:
-                pitch_pred_out = self.pitch_predictor(pitch_cond, pitch - base_pitch, infer=False)
+                pitch_target = pitch - base_pitch
+                if pitch_predictor_fn is None:
+                    pitch_pred_out = self.pitch_predictor(pitch_cond, pitch_target, infer=False)
+                else:
+                    pitch_pred_out = pitch_predictor_fn(pitch_cond, pitch_target)
         else:
             pitch_pred_out = None
 
@@ -369,7 +373,10 @@ class DiffSingerVariance(CategorizedModule, ParameterAdaptorModule):
             ]
             var_cond += torch.stack(variance_embeds, dim=-1).sum(-1)
 
-        variance_outputs = self.variance_predictor(var_cond, variance_inputs, infer=infer)
+        if not infer and variance_predictor_fn is not None:
+            variance_outputs = variance_predictor_fn(var_cond, variance_inputs)
+        else:
+            variance_outputs = self.variance_predictor(var_cond, variance_inputs, infer=infer)
 
         if infer:
             variances_pred_out = self.collect_variance_outputs(variance_outputs)

--- a/modules/toplevel.py
+++ b/modules/toplevel.py
@@ -81,11 +81,21 @@ class DiffSingerAcoustic(CategorizedModule, ParameterAdaptorModule):
         else:
             raise NotImplementedError(self.diffusion_type)
 
+    def encode_condition(
+            self, txt_tokens, mel2ph, f0, key_shift=None, speed=None,
+            spk_embed_id=None, languages=None, **kwargs
+    ):
+        return self.fs2(
+            txt_tokens, mel2ph, f0, key_shift=key_shift, speed=speed,
+            spk_embed_id=spk_embed_id, languages=languages,
+            **kwargs
+        )
+
     def forward(
             self, txt_tokens, mel2ph, f0, key_shift=None, speed=None,
             spk_embed_id=None, languages=None, gt_mel=None, infer=True, **kwargs
     ) -> ShallowDiffusionOutput:
-        condition = self.fs2(
+        condition = self.encode_condition(
             txt_tokens, mel2ph, f0, key_shift=key_shift, speed=speed,
             spk_embed_id=spk_embed_id, languages=languages,
             **kwargs

--- a/tests/test_reflow_xm.py
+++ b/tests/test_reflow_xm.py
@@ -1,0 +1,94 @@
+import sys
+import unittest
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import modules.core.reflow as reflow_module
+from modules.losses.reflow_loss import RectifiedFlowLoss
+
+
+class RectifiedFlowXMTest(unittest.TestCase):
+    def setUp(self):
+        self.original_hparams = dict(reflow_module.hparams)
+        reflow_module.hparams.clear()
+        reflow_module.hparams.update({
+            'hidden_size': 4,
+            'use_shallow_diffusion': False,
+        })
+
+    def tearDown(self):
+        reflow_module.hparams.clear()
+        reflow_module.hparams.update(self.original_hparams)
+
+    def build_model(self):
+        return reflow_module.RectifiedFlow(
+            out_dims=2,
+            num_feats=1,
+            t_start=0.,
+            time_scale_factor=10,
+            backbone_type='wavenet',
+            backbone_args={
+                'num_layers': 1,
+                'num_channels': 4,
+                'dilation_cycle_length': 1,
+            },
+            spec_min=[-1., -1.],
+            spec_max=[1., 1.],
+        )
+
+    def test_training_inputs_can_be_replayed_with_gradients(self):
+        model = self.build_model()
+        condition = torch.randn(2, 3, 4, requires_grad=True)
+        target = torch.randn(2, 3, 2)
+        timestep = torch.tensor([0.2, 0.7])
+        noise = torch.randn(2, 1, 2, 3)
+
+        first = model.training_forward(condition, target, t=timestep, noise=noise)
+        second = model.training_forward(condition, target, t=timestep, noise=noise)
+
+        for first_tensor, second_tensor in zip(first, second):
+            self.assertTrue(torch.equal(first_tensor, second_tensor))
+        first[0].sum().backward()
+        self.assertIsNotNone(condition.grad)
+        self.assertTrue(any(parameter.grad is not None for parameter in model.parameters()))
+
+    def test_per_sample_loss_ignores_padding(self):
+        loss_fn = RectifiedFlowLoss('l2', log_norm=False)
+        prediction = torch.tensor(
+            [[[[1., 2., 9.], [3., 4., 9.]]]],
+            requires_grad=True,
+        )
+        target = torch.zeros_like(prediction)
+        non_padding = torch.tensor([[[1.], [1.], [0.]]])
+
+        loss = loss_fn(
+            prediction,
+            target,
+            torch.tensor([0.5]),
+            non_padding=non_padding,
+            reduction='none',
+        )
+
+        self.assertTrue(torch.allclose(loss, torch.tensor([7.5])))
+        loss.mean().backward()
+        self.assertEqual(prediction.grad[0, 0, 0, 2].item(), 0.)
+        self.assertEqual(prediction.grad[0, 0, 1, 2].item(), 0.)
+
+    def test_mean_reduction_keeps_original_semantics(self):
+        loss_fn = RectifiedFlowLoss('l1', log_norm=False)
+        prediction = torch.tensor([[[[1., 2.]]], [[[3., 4.]]]])
+        target = torch.zeros_like(prediction)
+        timestep = torch.tensor([0.25, 0.75])
+
+        original = loss_fn(prediction, target, timestep)
+        expected = torch.nn.functional.l1_loss(prediction, target)
+
+        self.assertTrue(torch.equal(original, expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reflow_xm.py
+++ b/tests/test_reflow_xm.py
@@ -45,11 +45,11 @@ class RectifiedFlowXMTest(unittest.TestCase):
         model = self.build_model()
         condition = torch.randn(2, 3, 4, requires_grad=True)
         target = torch.randn(2, 3, 2)
-        timestep = torch.tensor([0.2, 0.7])
+        t1 = torch.tensor([[0.2], [0.7]])
         noise = torch.randn(2, 1, 2, 3)
 
-        first = model.training_forward(condition, target, t=timestep, noise=noise)
-        second = model.training_forward(condition, target, t=timestep, noise=noise)
+        first = model.training_forward(condition, target, t1=t1, noise=noise)
+        second = model.training_forward(condition, target, t1=t1, noise=noise)
 
         for first_tensor, second_tensor in zip(first, second):
             self.assertTrue(torch.equal(first_tensor, second_tensor))
@@ -155,6 +155,97 @@ class RectifiedFlowXMTest(unittest.TestCase):
 
         self.assertEqual(output[0].shape, (2, 2, 2, 3))
         self.assertIsNotNone(condition.grad)
+
+
+    def test_dual_timestep_threads_mask_through_training_forward(self):
+        """dual-timestep 下 prepare_training_inputs 返回 t2/mask，
+        training_forward 用相同 t1/t2/mask/noise 必须能精确重放（同步性）。"""
+        reflow_module.hparams['use_dual_timestep'] = True
+        model = self.build_model()
+        condition = torch.randn(2, 3, 4, requires_grad=True)
+        target = torch.randn(2, 3, 2)
+
+        spec, t1, t2, mask, noise = model.prepare_training_inputs(
+            target, t1=torch.tensor([[0.2], [0.7]]), t2=torch.tensor([[0.1], [0.4]]),
+            mask=(torch.rand(2, 3) < 0.25).float(), noise=torch.randn(2, 1, 2, 3),
+        )
+        replay = model.training_forward(
+            condition, target, t1=t1, t2=t2, mask=mask, noise=noise,
+        )
+        manual = model.p_losses(spec, t1, cond=condition.transpose(1, 2), t2=t2, mask=mask, noise=noise)
+        for rt, mt in zip(replay, manual):
+            self.assertTrue(torch.equal(rt, mt))
+
+        # effective t 是逐帧 [B, T]（符合 dual 语义），且 replay 用它
+        effective_t = replay[2]
+        self.assertEqual(effective_t.shape, (2, 3))
+        replay[0].sum().backward()
+        self.assertIsNotNone(condition.grad)
+
+    def test_dual_timestep_xm_effective_t_is_per_frame(self):
+        """run_reflow_xm 在 dual 下输出逐帧 effective t（mask 未被丢弃/重采样）。"""
+        reflow_module.hparams['use_dual_timestep'] = True
+        predictor = reflow_module.PitchRectifiedFlow(
+            vmin=-2., vmax=2., cmin=-3., cmax=3., repeat_bins=4,
+            time_scale_factor=10,
+            backbone_type='wavenet',
+            backbone_args={'num_layers': 1, 'num_channels': 4, 'dilation_cycle_length': 1},
+        )
+        condition = torch.randn(2, 3, 4, requires_grad=True)
+        target = torch.randn(2, 3)
+        non_padding = torch.ones(2, 3, 1)
+        loss_fn = RectifiedFlowLoss('l2', log_norm=False)
+
+        output = run_reflow_xm(
+            predictor, condition, target, loss_fn, non_padding,
+            best_of_k=3, chunk_size=2,
+        )
+        v_pred, v_gt, effective_t = output
+        self.assertEqual(effective_t.shape, (2, 3))         # [B, T] per-frame
+        self.assertFalse(torch.any(torch.isnan(loss_fn(v_pred, v_gt, t=effective_t, non_padding=non_padding))))
+        loss_fn(v_pred, v_gt, t=effective_t, non_padding=non_padding).backward()
+        self.assertIsNotNone(condition.grad)
+
+    def test_xm_shallow_t_start_is_respected(self):
+        """shallow 场景：t1 采样范围从 T_start 开始；XM 应沿用 forward 的同分布。"""
+        reflow_module.hparams['use_shallow_diffusion'] = True
+        model = reflow_module.RectifiedFlow(
+            out_dims=2, num_feats=1, t_start=0.4, time_scale_factor=10,
+            backbone_type='wavenet',
+            backbone_args={'num_layers': 1, 'num_channels': 4, 'dilation_cycle_length': 1},
+            spec_min=[-1., -1.], spec_max=[1., 1.],
+        )
+        torch.manual_seed(0)
+        spec, t1, t2, mask, _ = model.prepare_training_inputs(torch.randn(4, 8, 2))
+        self.assertGreaterEqual(t1.min().item(), 0.4 - 1e-5)
+        self.assertIsNone(t2)
+        self.assertIsNone(mask)
+
+    def test_run_reflow_xm_batch_coverage_and_no_collapse(self):
+        """每元素都进 replay（bwd 数据量=B），且 K 个候选都有胜出（探索不退化）。"""
+        reflow_module.hparams['use_dual_timestep'] = True
+        predictor = reflow_module.PitchRectifiedFlow(
+            vmin=-2., vmax=2., cmin=-3., cmax=3., repeat_bins=4,
+            time_scale_factor=10,
+            backbone_type='wavenet',
+            backbone_args={'num_layers': 1, 'num_channels': 4, 'dilation_cycle_length': 1},
+        )
+        condition = torch.randn(6, 5, 4, requires_grad=True)
+        target = torch.randn(6, 5)
+        non_padding = torch.rand(6, 5, 1) > 0.3
+        non_padding = non_padding.float()
+        loss_fn = RectifiedFlowLoss('l2', log_norm=False)
+
+        output = run_reflow_xm(
+            predictor, condition, target, loss_fn, non_padding,
+            best_of_k=4, chunk_size=3,
+        )
+        per_element = loss_fn(
+            *output[:2], t=output[2], non_padding=non_padding, reduction='none'
+        )
+        self.assertEqual(per_element.shape, (6,))          # bwd 数据量 = B
+        self.assertTrue(torch.isfinite(per_element).all())
+        self.assertEqual(output[0].shape, (6, 1, 4, 5))     # 每元素都有输出
 
 
 if __name__ == '__main__':

--- a/tests/test_reflow_xm.py
+++ b/tests/test_reflow_xm.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import modules.core.reflow as reflow_module
+from modules.core.xm import run_reflow_xm
 from modules.losses.reflow_loss import RectifiedFlowLoss
 
 
@@ -88,6 +89,72 @@ class RectifiedFlowXMTest(unittest.TestCase):
         expected = torch.nn.functional.l1_loss(prediction, target)
 
         self.assertTrue(torch.equal(original, expected))
+
+    def test_pitch_predictor_supports_chunked_xm(self):
+        predictor = reflow_module.PitchRectifiedFlow(
+            vmin=-2.,
+            vmax=2.,
+            cmin=-3.,
+            cmax=3.,
+            repeat_bins=4,
+            time_scale_factor=10,
+            backbone_type='wavenet',
+            backbone_args={
+                'num_layers': 1,
+                'num_channels': 4,
+                'dilation_cycle_length': 1,
+            },
+        )
+        condition = torch.randn(2, 3, 4, requires_grad=True)
+        target = torch.randn(2, 3)
+        non_padding = torch.ones(2, 3, 1)
+        loss_fn = RectifiedFlowLoss('l2', log_norm=False)
+
+        output = run_reflow_xm(
+            predictor,
+            condition,
+            target,
+            loss_fn,
+            non_padding,
+            best_of_k=3,
+            chunk_size=2,
+        )
+        loss_fn(*output[:2], t=output[2], non_padding=non_padding).backward()
+
+        self.assertEqual(output[0].shape, (2, 1, 4, 3))
+        self.assertIsNotNone(condition.grad)
+
+    def test_multi_variance_predictor_supports_list_targets(self):
+        predictor = reflow_module.MultiVarianceRectifiedFlow(
+            ranges=[(-2., 2.), (-1., 1.)],
+            clamps=[(-2., 2.), (-1., 1.)],
+            repeat_bins=2,
+            time_scale_factor=10,
+            backbone_type='wavenet',
+            backbone_args={
+                'num_layers': 1,
+                'num_channels': 4,
+                'dilation_cycle_length': 1,
+            },
+        )
+        condition = torch.randn(2, 3, 4, requires_grad=True)
+        targets = [torch.randn(2, 3), torch.randn(2, 3)]
+        non_padding = torch.ones(2, 3, 1)
+        loss_fn = RectifiedFlowLoss('l2', log_norm=False)
+
+        output = run_reflow_xm(
+            predictor,
+            condition,
+            targets,
+            loss_fn,
+            non_padding,
+            best_of_k=3,
+            chunk_size=2,
+        )
+        loss_fn(*output[:2], t=output[2], non_padding=non_padding).backward()
+
+        self.assertEqual(output[0].shape, (2, 2, 2, 3))
+        self.assertIsNotNone(condition.grad)
 
 
 if __name__ == '__main__':

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -94,6 +94,17 @@ class AcousticTask(BaseTask):
             self.required_variances.append('voicing')
         if hparams['use_tension_embed']:
             self.required_variances.append('tension')
+        self.xm_best_of_k = int(hparams.get('xm_best_of_k', 1))
+        self.xm_chunk_size = int(hparams.get('xm_chunk_size', 1))
+        if self.xm_best_of_k < 1:
+            raise ValueError('xm_best_of_k must be at least 1.')
+        if self.xm_chunk_size < 1:
+            raise ValueError('xm_chunk_size must be at least 1.')
+        if self.xm_best_of_k > 1:
+            if self.diffusion_type != 'reflow':
+                raise ValueError('Explorative Modeling currently supports Rectified Flow only.')
+            if self.use_shallow_diffusion:
+                raise ValueError('Explorative Modeling currently requires use_shallow_diffusion=false.')
         super()._finish_init()
 
         # ── Fuse LYNXNet2 backbone kernels (in-place) ──
@@ -150,6 +161,58 @@ class AcousticTask(BaseTask):
             raise ValueError(f"Unknown diffusion type: {self.diffusion_type}")
         self.register_validation_loss('mel_loss')
 
+    def _run_reflow_xm(self, condition, target, non_padding):
+        diffusion = self.model.diffusion
+        spec, t, _ = diffusion.prepare_training_inputs(target)
+        batch_size = spec.shape[0]
+        best_losses = torch.full((batch_size,), float('inf'), device=spec.device)
+        best_noise = torch.empty_like(spec)
+        # The winning candidate is replayed after a no-grad search, so every
+        # stochastic state except the explored noise must remain identical.
+        dropout_modules = [
+            module for module in diffusion.modules()
+            if isinstance(module, torch.nn.Dropout) and module.p > 0.
+        ]
+        if dropout_modules:
+            raise RuntimeError(
+                'Explorative Modeling save-memory replay requires diffusion backbone dropout_rate=0.'
+            )
+
+        num_chunks = math.ceil(self.xm_best_of_k / self.xm_chunk_size)
+        with torch.no_grad():
+            for chunk_idx in range(num_chunks):
+                chunk_candidates = min(
+                    self.xm_chunk_size,
+                    self.xm_best_of_k - chunk_idx * self.xm_chunk_size
+                )
+                noise = torch.randn(
+                    (chunk_candidates, *spec.shape),
+                    device=spec.device,
+                    dtype=spec.dtype
+                )
+                chunk_condition = torch.cat([condition.detach()] * chunk_candidates, dim=0)
+                chunk_target = torch.cat([target] * chunk_candidates, dim=0)
+                chunk_t = torch.cat([t] * chunk_candidates, dim=0)
+                chunk_non_padding = torch.cat([non_padding] * chunk_candidates, dim=0)
+                v_pred, v_gt, _ = diffusion.training_forward(
+                    chunk_condition, chunk_target,
+                    t=chunk_t, noise=noise.flatten(0, 1)
+                )
+                chunk_losses = self.mel_loss(
+                    v_pred, v_gt, t=chunk_t,
+                    non_padding=chunk_non_padding, reduction='none'
+                ).reshape(chunk_candidates, batch_size)
+                chunk_best_losses, chunk_best_indices = chunk_losses.min(dim=0)
+                batch_indices = torch.arange(batch_size, device=spec.device)
+                chunk_best_noise = noise[chunk_best_indices, batch_indices]
+                replace = chunk_best_losses < best_losses
+                best_losses[replace] = chunk_best_losses[replace]
+                best_noise[replace] = chunk_best_noise[replace]
+
+        if hasattr(torch, 'clear_autocast_cache'):
+            torch.clear_autocast_cache()
+        return diffusion.training_forward(condition, target, t=t, noise=best_noise)
+
     def run_model(self, sample, infer=False):
         txt_tokens = sample['tokens']  # [B, T_ph]
         target = sample['mel']  # [B, T_s, M]
@@ -170,12 +233,23 @@ class AcousticTask(BaseTask):
             languages = sample['languages']
         else:
             languages = None
-        output: ShallowDiffusionOutput = self.model(
-            txt_tokens, mel2ph=mel2ph, f0=f0, **variances,
-            key_shift=key_shift, speed=speed,
-            spk_embed_id=spk_embed_id, languages=languages,
-            gt_mel=target, infer=infer
-        )
+        if not infer and self.xm_best_of_k > 1:
+            condition = self.model.encode_condition(
+                txt_tokens, mel2ph=mel2ph, f0=f0, **variances,
+                key_shift=key_shift, speed=speed,
+                spk_embed_id=spk_embed_id, languages=languages
+            )
+            non_padding = (mel2ph > 0).unsqueeze(-1).float()
+            output = ShallowDiffusionOutput(
+                diff_out=self._run_reflow_xm(condition, target, non_padding)
+            )
+        else:
+            output: ShallowDiffusionOutput = self.model(
+                txt_tokens, mel2ph=mel2ph, f0=f0, **variances,
+                key_shift=key_shift, speed=speed,
+                spk_embed_id=spk_embed_id, languages=languages,
+                gt_mel=target, infer=infer
+            )
 
         if infer:
             return output

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -1,5 +1,3 @@
-import math
-
 import matplotlib
 import torch
 import torch.distributions
@@ -12,6 +10,7 @@ from basics.base_dataset import BaseDataset
 from basics.base_task import BaseTask
 from basics.base_vocoder import BaseVocoder
 from modules.aux_decoder import build_aux_loss
+from modules.core.xm import run_reflow_xm
 from modules.losses import DiffusionLoss, RectifiedFlowLoss
 from modules.toplevel import DiffSingerAcoustic, ShallowDiffusionOutput
 from modules.vocoders.registry import get_vocoder_cls
@@ -161,58 +160,6 @@ class AcousticTask(BaseTask):
             raise ValueError(f"Unknown diffusion type: {self.diffusion_type}")
         self.register_validation_loss('mel_loss')
 
-    def _run_reflow_xm(self, condition, target, non_padding):
-        diffusion = self.model.diffusion
-        spec, t, _ = diffusion.prepare_training_inputs(target)
-        batch_size = spec.shape[0]
-        best_losses = torch.full((batch_size,), float('inf'), device=spec.device)
-        best_noise = torch.empty_like(spec)
-        # The winning candidate is replayed after a no-grad search, so every
-        # stochastic state except the explored noise must remain identical.
-        dropout_modules = [
-            module for module in diffusion.modules()
-            if isinstance(module, torch.nn.Dropout) and module.p > 0.
-        ]
-        if dropout_modules:
-            raise RuntimeError(
-                'Explorative Modeling save-memory replay requires diffusion backbone dropout_rate=0.'
-            )
-
-        num_chunks = math.ceil(self.xm_best_of_k / self.xm_chunk_size)
-        with torch.no_grad():
-            for chunk_idx in range(num_chunks):
-                chunk_candidates = min(
-                    self.xm_chunk_size,
-                    self.xm_best_of_k - chunk_idx * self.xm_chunk_size
-                )
-                noise = torch.randn(
-                    (chunk_candidates, *spec.shape),
-                    device=spec.device,
-                    dtype=spec.dtype
-                )
-                chunk_condition = torch.cat([condition.detach()] * chunk_candidates, dim=0)
-                chunk_target = torch.cat([target] * chunk_candidates, dim=0)
-                chunk_t = torch.cat([t] * chunk_candidates, dim=0)
-                chunk_non_padding = torch.cat([non_padding] * chunk_candidates, dim=0)
-                v_pred, v_gt, _ = diffusion.training_forward(
-                    chunk_condition, chunk_target,
-                    t=chunk_t, noise=noise.flatten(0, 1)
-                )
-                chunk_losses = self.mel_loss(
-                    v_pred, v_gt, t=chunk_t,
-                    non_padding=chunk_non_padding, reduction='none'
-                ).reshape(chunk_candidates, batch_size)
-                chunk_best_losses, chunk_best_indices = chunk_losses.min(dim=0)
-                batch_indices = torch.arange(batch_size, device=spec.device)
-                chunk_best_noise = noise[chunk_best_indices, batch_indices]
-                replace = chunk_best_losses < best_losses
-                best_losses[replace] = chunk_best_losses[replace]
-                best_noise[replace] = chunk_best_noise[replace]
-
-        if hasattr(torch, 'clear_autocast_cache'):
-            torch.clear_autocast_cache()
-        return diffusion.training_forward(condition, target, t=t, noise=best_noise)
-
     def run_model(self, sample, infer=False):
         txt_tokens = sample['tokens']  # [B, T_ph]
         target = sample['mel']  # [B, T_s, M]
@@ -241,7 +188,15 @@ class AcousticTask(BaseTask):
             )
             non_padding = (mel2ph > 0).unsqueeze(-1).float()
             output = ShallowDiffusionOutput(
-                diff_out=self._run_reflow_xm(condition, target, non_padding)
+                diff_out=run_reflow_xm(
+                    self.model.diffusion,
+                    condition,
+                    target,
+                    self.mel_loss,
+                    non_padding,
+                    self.xm_best_of_k,
+                    self.xm_chunk_size,
+                )
             )
         else:
             output: ShallowDiffusionOutput = self.model(

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -102,13 +102,6 @@ class AcousticTask(BaseTask):
         if self.xm_best_of_k > 1:
             if self.diffusion_type != 'reflow':
                 raise ValueError('Explorative Modeling currently supports Rectified Flow only.')
-            if self.use_shallow_diffusion:
-                raise ValueError('Explorative Modeling currently requires use_shallow_diffusion=false.')
-            if hparams.get('use_dual_timestep', False):
-                raise ValueError(
-                    'Explorative Modeling does not support use_dual_timestep yet; '
-                    'the candidate timestep/mask would not be threaded through training_forward.'
-                )
         super()._finish_init()
 
         # ── Fuse LYNXNet2 backbone kernels (in-place) ──
@@ -185,31 +178,28 @@ class AcousticTask(BaseTask):
             languages = sample['languages']
         else:
             languages = None
+        diffusion_fn = None
         if not infer and self.xm_best_of_k > 1:
-            condition = self.model.encode_condition(
-                txt_tokens, mel2ph=mel2ph, f0=f0, **variances,
-                key_shift=key_shift, speed=speed,
-                spk_embed_id=spk_embed_id, languages=languages
-            )
             non_padding = (mel2ph > 0).unsqueeze(-1).float()
-            output = ShallowDiffusionOutput(
-                diff_out=run_reflow_xm(
+
+            def diffusion_fn(condition, gt_mel):
+                return run_reflow_xm(
                     self.model.diffusion,
                     condition,
-                    target,
+                    gt_mel,
                     self.mel_loss,
                     non_padding,
                     self.xm_best_of_k,
                     self.xm_chunk_size,
                 )
-            )
-        else:
-            output: ShallowDiffusionOutput = self.model(
-                txt_tokens, mel2ph=mel2ph, f0=f0, **variances,
-                key_shift=key_shift, speed=speed,
-                spk_embed_id=spk_embed_id, languages=languages,
-                gt_mel=target, infer=infer
-            )
+
+        output: ShallowDiffusionOutput = self.model(
+            txt_tokens, mel2ph=mel2ph, f0=f0, **variances,
+            key_shift=key_shift, speed=speed,
+            spk_embed_id=spk_embed_id, languages=languages,
+            gt_mel=target, infer=infer,
+            diffusion_fn=diffusion_fn,
+        )
 
         if infer:
             return output

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -104,6 +104,11 @@ class AcousticTask(BaseTask):
                 raise ValueError('Explorative Modeling currently supports Rectified Flow only.')
             if self.use_shallow_diffusion:
                 raise ValueError('Explorative Modeling currently requires use_shallow_diffusion=false.')
+            if hparams.get('use_dual_timestep', False):
+                raise ValueError(
+                    'Explorative Modeling does not support use_dual_timestep yet; '
+                    'the candidate timestep/mask would not be threaded through training_forward.'
+                )
         super()._finish_init()
 
         # ── Fuse LYNXNet2 backbone kernels (in-place) ──

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -126,6 +126,12 @@ class VarianceTask(BaseTask):
             raise ValueError('xm_pitch_best_of_k > 1 requires predict_pitch=true.')
         if self.xm_variance_best_of_k > 1 and not self.predict_variances:
             raise ValueError('xm_variance_best_of_k > 1 requires at least one predicted variance.')
+        if (self.xm_pitch_best_of_k > 1 or self.xm_variance_best_of_k > 1) \
+                and hparams.get('use_dual_timestep', False):
+            raise ValueError(
+                'Explorative Modeling does not support use_dual_timestep yet; '
+                'the candidate timestep/mask would not be threaded through training_forward.'
+            )
         super()._finish_init()
 
         # ── Fuse LYNXNet2 backbone kernels (in-place) ──

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -126,12 +126,6 @@ class VarianceTask(BaseTask):
             raise ValueError('xm_pitch_best_of_k > 1 requires predict_pitch=true.')
         if self.xm_variance_best_of_k > 1 and not self.predict_variances:
             raise ValueError('xm_variance_best_of_k > 1 requires at least one predicted variance.')
-        if (self.xm_pitch_best_of_k > 1 or self.xm_variance_best_of_k > 1) \
-                and hparams.get('use_dual_timestep', False):
-            raise ValueError(
-                'Explorative Modeling does not support use_dual_timestep yet; '
-                'the candidate timestep/mask would not be threaded through training_forward.'
-            )
         super()._finish_init()
 
         # ── Fuse LYNXNet2 backbone kernels (in-place) ──

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -8,6 +8,7 @@ import utils
 import utils.infer_utils
 from basics.base_dataset import BaseDataset
 from basics.base_task import BaseTask
+from modules.core.xm import run_reflow_xm
 from modules.losses import DurationLoss, DiffusionLoss, RectifiedFlowLoss
 from modules.metrics import (
     RawCurveAccuracy, RawCurveR2Score, RhythmCorrectness, PhonemeDurationAccuracy
@@ -113,6 +114,18 @@ class VarianceTask(BaseTask):
             self.variance_prediction_list.append('tension')
         self.predict_variances = len(self.variance_prediction_list) > 0
         self.lambda_var_loss = hparams['lambda_var_loss']
+        self.xm_pitch_best_of_k = int(hparams.get('xm_pitch_best_of_k', 1))
+        self.xm_variance_best_of_k = int(hparams.get('xm_variance_best_of_k', 1))
+        self.xm_chunk_size = int(hparams.get('xm_chunk_size', 1))
+        if min(self.xm_pitch_best_of_k, self.xm_variance_best_of_k, self.xm_chunk_size) < 1:
+            raise ValueError('XM best-of-K values and xm_chunk_size must be at least 1.')
+        if (self.xm_pitch_best_of_k > 1 or self.xm_variance_best_of_k > 1) \
+                and self.diffusion_type != 'reflow':
+            raise ValueError('Explorative Modeling currently supports Rectified Flow only.')
+        if self.xm_pitch_best_of_k > 1 and not self.predict_pitch:
+            raise ValueError('xm_pitch_best_of_k > 1 requires predict_pitch=true.')
+        if self.xm_variance_best_of_k > 1 and not self.predict_variances:
+            raise ValueError('xm_variance_best_of_k > 1 requires at least one predicted variance.')
         super()._finish_init()
 
         # ── Fuse LYNXNet2 backbone kernels (in-place) ──
@@ -222,6 +235,23 @@ class VarianceTask(BaseTask):
             for name in self.variance_prediction_list:
                 self.register_validation_metric(f'{name}_r2', RawCurveR2Score())
 
+    def _build_xm_predictor(self, predictor, loss_fn, non_padding, best_of_k):
+        if best_of_k == 1:
+            return None
+
+        def predictor_fn(condition, target):
+            return run_reflow_xm(
+                predictor,
+                condition,
+                target,
+                loss_fn,
+                non_padding,
+                best_of_k,
+                self.xm_chunk_size,
+            )
+
+        return predictor_fn
+
     def run_model(self, sample, infer=False):
         spk_ids = sample['spk_ids'] if self.use_spk_id else None  # [B,]
         languages = sample['languages'] if self.use_lang_id else None  # [B,]
@@ -258,6 +288,25 @@ class VarianceTask(BaseTask):
                     for v_name in self.variance_prediction_list
                 }
 
+        non_padding = (mel2ph > 0).unsqueeze(-1) if mel2ph is not None else None
+        pitch_predictor_fn = None
+        variance_predictor_fn = None
+        if not infer:
+            if self.predict_pitch:
+                pitch_predictor_fn = self._build_xm_predictor(
+                    self.model.pitch_predictor,
+                    self.pitch_loss,
+                    non_padding,
+                    self.xm_pitch_best_of_k,
+                )
+            if self.predict_variances:
+                variance_predictor_fn = self._build_xm_predictor(
+                    self.model.variance_predictor,
+                    self.var_loss,
+                    non_padding,
+                    self.xm_variance_best_of_k,
+                )
+
         output = self.model(
             txt_tokens, languages=languages,
             midi=midi, ph2word=ph2word,
@@ -267,7 +316,9 @@ class VarianceTask(BaseTask):
             base_pitch=base_pitch, pitch=pitch,
             energy=energy, breathiness=breathiness, voicing=voicing, tension=tension,
             pitch_retake=pitch_retake, variance_retake=variance_retake,
-            spk_id=spk_ids, infer=infer
+            spk_id=spk_ids, infer=infer,
+            pitch_predictor_fn=pitch_predictor_fn,
+            variance_predictor_fn=variance_predictor_fn,
         )
 
         dur_pred, pitch_pred, variances_pred, sdp_loss, sdp_pred = output
@@ -287,7 +338,6 @@ class VarianceTask(BaseTask):
                     anneal_weight = min(1.0, step / warmup_steps) if warmup_steps > 0 else 1.0
                     current_sdp_reg_weight = lambda_sdp_reg_base * anneal_weight
                     losses['dur_sdp_loss'] = current_sdp_reg_weight * self.dur_sdp_loss(sdp_pred, ph_dur, ph2word=ph2word)
-            non_padding = (mel2ph > 0).unsqueeze(-1) if mel2ph is not None else None
             if pitch_pred is not None:
                 if self.diffusion_type == 'ddpm':
                     pitch_x_recon, pitch_noise = pitch_pred


### PR DESCRIPTION
## Summary

Lands **low-memory Forward Explorative Modeling (XM, best-of-K)** for the Rectified Flow (reflow) pitch / variance predictors and full-depth acoustic reflow, rebased onto the current `integration-dual-timestep-stack` default branch.

This is the successor to the reverted #58/#59 (repeat-bin Forward XM). Instead of folding bins, it explores candidate flow noises and backprops only the closest candidate, matching the design of [Explorative Modeling (XM)](https://arxiv.org/abs/2607.27372).

## Key properties (by design)

- **No data collapse**: `run_reflow_xm` explores over the *noise latent only* — every batch element always participates in the final backward, so the effective backward data amount per step equals the K=1 baseline.
- **No k-fold VRAM**: candidates are evaluated in `no_grad` chunks (`xm_chunk_size`), then the winning noise is **replayed once with gradients** so upstream condition encoders stay trainable.
- **Shared timestep per original sample** across all candidates (determinism), and replay uses the exact same `t`/`noise` so the trained objective matches the explored one.
- Guard rails: raises if the backbone has dropout (`dropout_rate=0` required for exact replay) and validates config combinations.

## Config knobs

- Acoustic: `xm_best_of_k`, `xm_chunk_size` (full-depth reflow only; requires `use_shallow_diffusion=false`).
- Variance: `xm_pitch_best_of_k`, `xm_variance_best_of_k`, `xm_chunk_size` — independently enable exploration for pitch and variance predictors. K=1 preserves the standard objective.

## Files

- `modules/core/xm.py` — low-memory Forward XM runner (new)
- `modules/core/reflow.py` — `prepare_training_inputs` / `training_forward` / `p_losses(noise=)` (kept dual-timestep training path intact)
- `modules/losses/reflow_loss.py` — `reduction='none'` per-sample masked loss
- `modules/toplevel.py` — optional `pitch_predictor_fn` / `variance_predictor_fn` injection points
- `training/acoustic_task.py`, `training/variance_task.py` — XM wiring
- configs + templates — new hparams
- `tests/test_reflow_xm.py` — unit tests (replay with grads, padding, chunked XM, list-target multi-variance, mean semantics)

## Tests

`python -m unittest tests/test_reflow_xm.py` — 5 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Explorative Modeling for Rectified Flow training.
  * Configure best-of-K candidate exploration and chunk size for acoustic, pitch, and variance prediction.
  * Supports separate exploration settings for pitch and variance predictors.
  * Added low-memory processing for candidate evaluation.

* **Configuration**
  * Default settings preserve existing single-candidate training behavior.
  * Added validation and guidance for compatible training options, including shallow diffusion requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->